### PR TITLE
Support angle in number functions

### DIFF
--- a/include/keisan/number.hpp
+++ b/include/keisan/number.hpp
@@ -55,6 +55,9 @@ T map(
 template<typename T, enable_if_is_arithmetic<T> = true>
 T clamp(const T & value, const T & min, const T & max);
 
+template<typename T>
+Angle<T> clamp(const Angle<T> & value, const Angle<T> & min, const Angle<T> & max);
+
 template<typename T, enable_if_is_floating_point<T> = true>
 T wrap(const T & value, const T & min, const T & max);
 

--- a/include/keisan/number.hpp
+++ b/include/keisan/number.hpp
@@ -27,6 +27,9 @@ namespace keisan
 {
 
 template<typename T>
+class Angle;
+
+template<typename T>
 using enable_if_is_integral = std::enable_if_t<std::is_integral<T>::value, bool>;
 
 template<typename T>
@@ -37,6 +40,9 @@ using enable_if_is_arithmetic = std::enable_if_t<std::is_arithmetic<T>::value, b
 
 template<typename T, enable_if_is_arithmetic<T> = true>
 T sign(const T & value);
+
+template<typename T>
+T sign(const Angle<T> & value);
 
 template<typename T, enable_if_is_arithmetic<T> = true>
 T scale(const T & value, const T & source, const T & target);

--- a/include/keisan/number.impl.hpp
+++ b/include/keisan/number.impl.hpp
@@ -62,6 +62,20 @@ T clamp(const T & value, const T & min, const T & max)
   return std::min(std::max(value, min), max);
 }
 
+template<typename T>
+Angle<T> clamp(const Angle<T> & value, const Angle<T> & min, const Angle<T> & max)
+{
+  if (value < min) {
+    return min;
+  }
+
+  if (value > max) {
+    return max;
+  }
+
+  return value;
+}
+
 template<typename T, enable_if_is_floating_point<T> = true>
 T wrap(const T & value, const T & min, const T & max)
 {

--- a/include/keisan/number.impl.hpp
+++ b/include/keisan/number.impl.hpp
@@ -21,6 +21,7 @@
 #ifndef KEISAN__NUMBER_IMPL_HPP_
 #define KEISAN__NUMBER_IMPL_HPP_
 
+#include <keisan/angle.hpp>
 #include <keisan/number.hpp>
 
 #include <algorithm>
@@ -33,6 +34,12 @@ template<typename T, enable_if_is_arithmetic<T> = true>
 T sign(const T & value)
 {
   return (value >= 0) ? 1 : -1;
+}
+
+template<typename T>
+T sign(const Angle<T> & value)
+{
+  return (value >= make_degree<T>(0)) ? 1.0 : -1.0;
 }
 
 template<typename T, enable_if_is_arithmetic<T> = true>

--- a/include/keisan/number.impl.hpp
+++ b/include/keisan/number.impl.hpp
@@ -18,61 +18,61 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef KEISAN__NUMBER_HPP_
-#define KEISAN__NUMBER_HPP_
+#ifndef KEISAN__NUMBER_IMPL_HPP_
+#define KEISAN__NUMBER_IMPL_HPP_
 
-#include <type_traits>
+#include <keisan/number.hpp>
+
+#include <algorithm>
+#include <cmath>
 
 namespace keisan
 {
 
-template<typename T>
-using enable_if_is_integral = std::enable_if_t<std::is_integral<T>::value, bool>;
-
-template<typename T>
-using enable_if_is_floating_point = std::enable_if_t<std::is_floating_point<T>::value, bool>;
-
-template<typename T>
-using enable_if_is_arithmetic = std::enable_if_t<std::is_arithmetic<T>::value, bool>;
+template<typename T, enable_if_is_arithmetic<T> = true>
+T sign(const T & value)
+{
+  return (value >= 0) ? 1 : -1;
+}
 
 template<typename T, enable_if_is_arithmetic<T> = true>
-T sign(const T & value);
-
-template<typename T, enable_if_is_arithmetic<T> = true>
-T scale(const T & value, const T & source, const T & target);
+T scale(const T & value, const T & source, const T & target)
+{
+  return value / source * target;
+}
 
 template<typename T, enable_if_is_arithmetic<T> = true>
 T map(
   const T & value, const T & source_min, const T & source_max,
-  const T & target_min, const T & target_max);
+  const T & target_min, const T & target_max)
+{
+  return target_min + scale(value - source_min, source_max - source_min, target_max - target_min);
+}
 
 template<typename T, enable_if_is_arithmetic<T> = true>
-T clamp(const T & value, const T & min, const T & max);
+T clamp(const T & value, const T & min, const T & max)
+{
+  return std::min(std::max(value, min), max);
+}
 
 template<typename T, enable_if_is_floating_point<T> = true>
-T wrap(const T & value, const T & min, const T & max);
+T wrap(const T & value, const T & min, const T & max)
+{
+  auto min_value = value - min;
+  auto min_max = max - min;
+
+  return min + std::fmod(min_max + std::fmod(min_value, min_max), min_max);
+}
 
 template<typename T, enable_if_is_integral<T> = true>
-T wrap(const T & value, const T & min, const T & max);
+T wrap(const T & value, const T & min, const T & max)
+{
+  auto min_value = value - min;
+  auto min_max = max - min;
 
-[[deprecated("Use sign() instead.")]]
-double sign_number(double value);
-
-[[deprecated("Use scale() instead.")]]
-double scale_number(double value, double source, double target);
-
-[[deprecated("Use map() instead.")]]
-double map_number(
-  double value, double source_min, double source_max, double target_min, double target_max);
-
-[[deprecated("Use clamp() instead.")]]
-double clamp_number(double value, double min, double max);
-
-[[deprecated("Use wrap() instead.")]]
-double wrap_number(double value, double min, double max);
+  return min + (min_max + min_value % min_max) % min_max;
+}
 
 }  // namespace keisan
 
-#include <keisan/number.impl.hpp>  // NOLINT
-
-#endif  // KEISAN__NUMBER_HPP_
+#endif  // KEISAN__NUMBER_IMPL_HPP_

--- a/test/angle/angle_test.cpp
+++ b/test/angle/angle_test.cpp
@@ -25,40 +25,42 @@
 
 #include "keisan/keisan.hpp"
 
-using namespace keisan::literals;  // NOLINT
+namespace ksn = keisan;
+
+using namespace ksn::literals;  // NOLINT
 
 TEST(AngleTest, MakeDegree)
 {
-  EXPECT_FLOAT_EQ(keisan::make_degree(90.0f).degree(), 90.0f);
-  EXPECT_DOUBLE_EQ(keisan::make_degree(-45.0).degree(), -45.0);
-  EXPECT_DOUBLE_EQ(keisan::make_degree(15.0l).degree(), 15.0l);
+  EXPECT_FLOAT_EQ(ksn::make_degree(90.0f).degree(), 90.0f);
+  EXPECT_DOUBLE_EQ(ksn::make_degree(-45.0).degree(), -45.0);
+  EXPECT_DOUBLE_EQ(ksn::make_degree(15.0l).degree(), 15.0l);
 }
 
 TEST(AngleTest, MakeRadian)
 {
-  EXPECT_FLOAT_EQ(keisan::make_radian<float>(0.5_pi).radian(), 0.5_pi);
-  EXPECT_DOUBLE_EQ(keisan::make_radian<double>(-0.25_pi).radian(), -0.25_pi);
-  EXPECT_DOUBLE_EQ(keisan::make_radian<long double>(0.1_pi).radian(), 0.1_pi);
+  EXPECT_FLOAT_EQ(ksn::make_radian<float>(0.5_pi).radian(), 0.5_pi);
+  EXPECT_DOUBLE_EQ(ksn::make_radian<double>(-0.25_pi).radian(), -0.25_pi);
+  EXPECT_DOUBLE_EQ(ksn::make_radian<long double>(0.1_pi).radian(), 0.1_pi);
 }
 
 TEST(AngleTest, DegLiterals)
 {
-  EXPECT_EQ(0_deg, keisan::make_degree(0.0));
-  EXPECT_EQ(90_deg, keisan::make_degree(90.0));
-  EXPECT_EQ(-45_deg, keisan::make_degree(-45.0));
-  EXPECT_EQ(0.0_deg, keisan::make_degree(0.0));
-  EXPECT_EQ(12.5_deg, keisan::make_degree(12.5));
-  EXPECT_EQ(-2.5_deg, keisan::make_degree(-2.5));
+  EXPECT_EQ(0_deg, ksn::make_degree(0.0));
+  EXPECT_EQ(90_deg, ksn::make_degree(90.0));
+  EXPECT_EQ(-45_deg, ksn::make_degree(-45.0));
+  EXPECT_EQ(0.0_deg, ksn::make_degree(0.0));
+  EXPECT_EQ(12.5_deg, ksn::make_degree(12.5));
+  EXPECT_EQ(-2.5_deg, ksn::make_degree(-2.5));
 }
 
 TEST(AngleTest, RadLiterals)
 {
-  EXPECT_EQ(0_pi_rad, keisan::make_radian<double>(0_pi));
-  EXPECT_EQ(1_pi_rad, keisan::make_radian<double>(1_pi));
-  EXPECT_EQ(-2_pi_rad, keisan::make_radian<double>(-2_pi));
-  EXPECT_EQ(0.0_pi_rad, keisan::make_radian<double>(0.0_pi));
-  EXPECT_EQ(0.5_pi_rad, keisan::make_radian<double>(0.5_pi));
-  EXPECT_EQ(-0.25_pi_rad, keisan::make_radian<double>(-0.25_pi));
+  EXPECT_EQ(0_pi_rad, ksn::make_radian<double>(0_pi));
+  EXPECT_EQ(1_pi_rad, ksn::make_radian<double>(1_pi));
+  EXPECT_EQ(-2_pi_rad, ksn::make_radian<double>(-2_pi));
+  EXPECT_EQ(0.0_pi_rad, ksn::make_radian<double>(0.0_pi));
+  EXPECT_EQ(0.5_pi_rad, ksn::make_radian<double>(0.5_pi));
+  EXPECT_EQ(-0.25_pi_rad, ksn::make_radian<double>(-0.25_pi));
 }
 
 TEST(AngleTest, OutputStream)
@@ -71,25 +73,25 @@ TEST(AngleTest, OutputStream)
 
 TEST(AngleTest, Empty)
 {
-  keisan::Angle<float> float_angle;
-  keisan::Angle<double> double_angle;
-  keisan::Angle<long double> long_double_angle;
+  ksn::Angle<float> float_angle;
+  ksn::Angle<double> double_angle;
+  ksn::Angle<long double> long_double_angle;
 }
 
 TEST(AngleTest, AssignmentConstructor)
 {
   #define EXPECT_CONVERSION_CONSTRUCTOR(TYPE, SOURCE) \
   { \
-    keisan::Angle<TYPE> a(SOURCE), b = SOURCE, c; \
+    ksn::Angle<TYPE> a(SOURCE), b = SOURCE, c; \
     c = SOURCE; \
     EXPECT_DOUBLE_EQ(a.degree(), SOURCE.degree()); \
     EXPECT_DOUBLE_EQ(b.degree(), SOURCE.degree()); \
     EXPECT_DOUBLE_EQ(c.degree(), SOURCE.degree()); \
   }
 
-  auto float_angle = keisan::make_degree(90.0f);
-  auto double_angle = keisan::make_degree(-45.0);
-  auto long_double_angle = keisan::make_degree(15.0l);
+  auto float_angle = ksn::make_degree(90.0f);
+  auto double_angle = ksn::make_degree(-45.0);
+  auto long_double_angle = ksn::make_degree(15.0l);
 
   #define LOOP_EXPECT_CONVERSION_CONSTRUCTOR(TYPE) \
   { \
@@ -176,7 +178,7 @@ TEST(AngleTest, Difference)
     "270 + (-1) * 360  = -90\n"
     "-90 - (-1pi) = 90";
 
-  EXPECT_EQ(keisan::difference_between(b, a), -0.5_pi_rad) <<
+  EXPECT_EQ(ksn::difference_between(b, a), -0.5_pi_rad) <<
     "-1pi + 0 * 2pi = -1pi\n"
     "270 + (-1) * 360  = -90\n"
     "-1pi - (-90) = -0.5pi";

--- a/test/angle/euler_angles_test.cpp
+++ b/test/angle/euler_angles_test.cpp
@@ -21,20 +21,22 @@
 #include <gtest/gtest.h>
 #include <keisan/keisan.hpp>
 
-using namespace keisan::literals;  // NOLINT
+namespace ksn = keisan;
+
+using namespace ksn::literals;  // NOLINT
 
 TEST(EulerAnglesTest, Empty) {
-  keisan::EulerAngles euler;
+  ksn::EulerAngles euler;
 }
 
 TEST(EulerAnglesTest, AssignValue) {
-  keisan::EulerAngles a(0.0_deg, 90.0_deg, 180.0_deg);
+  ksn::EulerAngles a(0.0_deg, 90.0_deg, 180.0_deg);
 
   ASSERT_DOUBLE_EQ(a.roll.degree(), 0.0);
   ASSERT_DOUBLE_EQ(a.pitch.degree(), 90.0);
   ASSERT_DOUBLE_EQ(a.yaw.degree(), 180.0);
 
-  keisan::EulerAngles b;
+  ksn::EulerAngles b;
   b = a;
 
   ASSERT_EQ(a.roll, b.roll);
@@ -43,9 +45,9 @@ TEST(EulerAnglesTest, AssignValue) {
 }
 
 TEST(EulerAnglesTest, ComparisonOperator) {
-  keisan::EulerAngles a(0.0_deg, 90.0_deg, 180.0_deg);
+  ksn::EulerAngles a(0.0_deg, 90.0_deg, 180.0_deg);
 
-  keisan::EulerAngles b = a;
+  ksn::EulerAngles b = a;
 
   ASSERT_TRUE(a == b);
   ASSERT_FALSE(a != b);
@@ -57,7 +59,7 @@ TEST(EulerAnglesTest, ComparisonOperator) {
 }
 
 TEST(EulerAnglesTest, QuaternionConversion) {
-  keisan::EulerAngles euler(0.0_deg, 0.0_deg, 90.0_deg);
+  ksn::EulerAngles euler(0.0_deg, 0.0_deg, 90.0_deg);
 
   auto quaternion = euler.quaternion();
 

--- a/test/angle/quaternion_test.cpp
+++ b/test/angle/quaternion_test.cpp
@@ -21,19 +21,21 @@
 #include <gtest/gtest.h>
 #include <keisan/keisan.hpp>
 
+namespace ksn = keisan;
+
 TEST(QuaternionTest, Empty) {
-  keisan::Quaternion quaternion;
+  ksn::Quaternion quaternion;
 }
 
 TEST(QuaternionTest, AssignValue) {
-  keisan::Quaternion a(1.0, 0.5, 0.0, -0.5);
+  ksn::Quaternion a(1.0, 0.5, 0.0, -0.5);
 
   ASSERT_DOUBLE_EQ(a.x, 1.0);
   ASSERT_DOUBLE_EQ(a.y, 0.5);
   ASSERT_DOUBLE_EQ(a.z, 0.0);
   ASSERT_DOUBLE_EQ(a.w, -0.5);
 
-  keisan::Quaternion b;
+  ksn::Quaternion b;
   b = a;
 
   ASSERT_DOUBLE_EQ(a.x, b.x);
@@ -43,8 +45,8 @@ TEST(QuaternionTest, AssignValue) {
 }
 
 TEST(QuaternionTest, ComparisonOperator) {
-  keisan::Quaternion a(1.0, 0.5, 0.0, -0.5);
-  keisan::Quaternion b = a;
+  ksn::Quaternion a(1.0, 0.5, 0.0, -0.5);
+  ksn::Quaternion b = a;
 
   ASSERT_TRUE(a == b);
   ASSERT_FALSE(a != b);

--- a/test/angle/trigonometry_test.cpp
+++ b/test/angle/trigonometry_test.cpp
@@ -22,66 +22,68 @@
 
 #include "keisan/keisan.hpp"
 
-using namespace keisan::literals;  // NOLINT
+namespace ksn = keisan;
+
+using namespace ksn::literals;  // NOLINT
 
 TEST(TrigonometryTest, PiValue)
 {
-  EXPECT_FLOAT_EQ(std::cos(keisan::pi<float>), -1.0f) << "cos(pi) = -1";
-  EXPECT_DOUBLE_EQ(std::cos(keisan::pi<double>), -1.0) << "cos(pi) = -1";
+  EXPECT_FLOAT_EQ(std::cos(ksn::pi<float>), -1.0f) << "cos(pi) = -1";
+  EXPECT_DOUBLE_EQ(std::cos(ksn::pi<double>), -1.0) << "cos(pi) = -1";
 }
 
 TEST(TrigonometryTest, PiIntegerLiterals)
 {
   EXPECT_DOUBLE_EQ(0_pi, 0.0);
-  EXPECT_DOUBLE_EQ(1_pi, 1.0 * keisan::pi<double>);
-  EXPECT_DOUBLE_EQ(-2_pi, -2.0 * keisan::pi<double>);
+  EXPECT_DOUBLE_EQ(1_pi, 1.0 * ksn::pi<double>);
+  EXPECT_DOUBLE_EQ(-2_pi, -2.0 * ksn::pi<double>);
 }
 
 TEST(TrigonometryTest, PiFloatingPointLiterals)
 {
   EXPECT_DOUBLE_EQ(0.0_pi, 0.0);
-  EXPECT_DOUBLE_EQ(1.5_pi, 1.5 * keisan::pi<double>);
-  EXPECT_DOUBLE_EQ(-0.25_pi, -0.25 * keisan::pi<double>);
+  EXPECT_DOUBLE_EQ(1.5_pi, 1.5 * ksn::pi<double>);
+  EXPECT_DOUBLE_EQ(-0.25_pi, -0.25 * ksn::pi<double>);
 }
 
 TEST(TrigonometryTest, Sin)
 {
-  EXPECT_FLOAT_EQ(keisan::sin<float>(30_deg), 0.5f) << "sin(30) = 0.5";
-  EXPECT_DOUBLE_EQ(keisan::sin<double>(30_deg), 0.5) << "sin(30) = 0.5";
+  EXPECT_FLOAT_EQ(ksn::sin<float>(30_deg), 0.5f) << "sin(30) = 0.5";
+  EXPECT_DOUBLE_EQ(ksn::sin<double>(30_deg), 0.5) << "sin(30) = 0.5";
 }
 
 TEST(TrigonometryTest, Cos)
 {
-  EXPECT_FLOAT_EQ(keisan::cos<float>(60_deg), 0.5f) << "cos(60) = 0.5";
-  EXPECT_DOUBLE_EQ(keisan::cos<double>(60_deg), 0.5) << "cos(60) = 0.5";
+  EXPECT_FLOAT_EQ(ksn::cos<float>(60_deg), 0.5f) << "cos(60) = 0.5";
+  EXPECT_DOUBLE_EQ(ksn::cos<double>(60_deg), 0.5) << "cos(60) = 0.5";
 }
 
 TEST(TrigonometryTest, Tan)
 {
-  EXPECT_FLOAT_EQ(keisan::tan<float>(45_deg), 1.0f) << "tan(45) = 1";
-  EXPECT_DOUBLE_EQ(keisan::tan<double>(45_deg), 1.0) << "tan(45) = 1";
+  EXPECT_FLOAT_EQ(ksn::tan<float>(45_deg), 1.0f) << "tan(45) = 1";
+  EXPECT_DOUBLE_EQ(ksn::tan<double>(45_deg), 1.0) << "tan(45) = 1";
 }
 
 TEST(TrigonometryTest, ArcSin)
 {
-  EXPECT_FLOAT_EQ(keisan::arcsin(0.5f).degree(), 30.0f) << "sin(30) = 0.5";
-  EXPECT_DOUBLE_EQ(keisan::arcsin(0.5).degree(), 30.0) << "sin(30) = 0.5";
+  EXPECT_FLOAT_EQ(ksn::arcsin(0.5f).degree(), 30.0f) << "sin(30) = 0.5";
+  EXPECT_DOUBLE_EQ(ksn::arcsin(0.5).degree(), 30.0) << "sin(30) = 0.5";
 }
 
 TEST(TrigonometryTest, ArcCos)
 {
-  EXPECT_FLOAT_EQ(keisan::arccos(0.5f).degree(), 60.0f) << "cos(60) = 0.5";
-  EXPECT_DOUBLE_EQ(keisan::arccos(0.5).degree(), 60.0) << "cos(60) = 0.5";
+  EXPECT_FLOAT_EQ(ksn::arccos(0.5f).degree(), 60.0f) << "cos(60) = 0.5";
+  EXPECT_DOUBLE_EQ(ksn::arccos(0.5).degree(), 60.0) << "cos(60) = 0.5";
 }
 
 TEST(TrigonometryTest, ArcTan)
 {
-  EXPECT_FLOAT_EQ(keisan::arctan(1.0f).degree(), 45.0f) << "tan(45) = 1";
-  EXPECT_DOUBLE_EQ(keisan::arctan(1.0).degree(), 45.0) << "tan(45) = 1";
+  EXPECT_FLOAT_EQ(ksn::arctan(1.0f).degree(), 45.0f) << "tan(45) = 1";
+  EXPECT_DOUBLE_EQ(ksn::arctan(1.0).degree(), 45.0) << "tan(45) = 1";
 }
 
 TEST(TrigonometryTest, SignedArcTan)
 {
-  EXPECT_FLOAT_EQ(keisan::signed_arctan(-1.0f, 1.0f).degree(), -45.0f);
-  EXPECT_DOUBLE_EQ(keisan::signed_arctan(-1.0, 1.0).degree(), -45.0);
+  EXPECT_FLOAT_EQ(ksn::signed_arctan(-1.0f, 1.0f).degree(), -45.0f);
+  EXPECT_DOUBLE_EQ(ksn::signed_arctan(-1.0, 1.0).degree(), -45.0);
 }

--- a/test/geometry/point_2_test.cpp
+++ b/test/geometry/point_2_test.cpp
@@ -23,9 +23,11 @@
 
 #include <sstream>
 
+namespace ksn = keisan;
+
 TEST(Point2Test, OutStream)
 {
-  auto point = keisan::Point2(1.0, 3.0);
+  auto point = ksn::Point2(1.0, 3.0);
 
   std::stringstream ss;
   ss << point;
@@ -35,7 +37,7 @@ TEST(Point2Test, OutStream)
 
 TEST(Point2Test, InitialValue)
 {
-  auto point = keisan::Point2(1.0, 3.0);
+  auto point = ksn::Point2(1.0, 3.0);
 
   ASSERT_DOUBLE_EQ(point.x, 1.0);
   ASSERT_DOUBLE_EQ(point.y, 3.0);
@@ -43,7 +45,7 @@ TEST(Point2Test, InitialValue)
 
 TEST(Point2Test, ZeroValue)
 {
-  auto point = keisan::Point2::zero();
+  auto point = ksn::Point2::zero();
 
   ASSERT_DOUBLE_EQ(point.x, 0.0);
   ASSERT_DOUBLE_EQ(point.y, 0.0);
@@ -51,7 +53,7 @@ TEST(Point2Test, ZeroValue)
 
 TEST(Point2Test, ComparisonOperation)
 {
-  auto a = keisan::Point2(1.0, 3.0);
+  auto a = ksn::Point2(1.0, 3.0);
   auto b = a;
 
   ASSERT_TRUE(a == b);
@@ -65,144 +67,144 @@ TEST(Point2Test, ComparisonOperation)
 
 TEST(Point2Test, SelfPointOperator)
 {
-  auto a = keisan::Point2(5.0, 4.0);
-  auto b = keisan::Point2(1.0, 3.0);
+  auto a = ksn::Point2(5.0, 4.0);
+  auto b = ksn::Point2(1.0, 3.0);
 
   a = b;
-  ASSERT_EQ(a, keisan::Point2(1.0, 3.0));
+  ASSERT_EQ(a, ksn::Point2(1.0, 3.0));
 
   a += b;
-  ASSERT_EQ(a, keisan::Point2(2.0, 6.0));
+  ASSERT_EQ(a, ksn::Point2(2.0, 6.0));
 
   a -= b;
-  ASSERT_EQ(a, keisan::Point2(1.0, 3.0));
+  ASSERT_EQ(a, ksn::Point2(1.0, 3.0));
 }
 
 TEST(Point2Test, SelfValueOperator)
 {
-  auto point = keisan::Point2(1.0, 3.0);
+  auto point = ksn::Point2(1.0, 3.0);
 
   point += 2.0;
-  ASSERT_EQ(point, keisan::Point2(3.0, 5.0));
+  ASSERT_EQ(point, ksn::Point2(3.0, 5.0));
 
   point -= 6.0;
-  ASSERT_EQ(point, keisan::Point2(-3.0, -1.0));
+  ASSERT_EQ(point, ksn::Point2(-3.0, -1.0));
 
   point *= 3.0;
-  ASSERT_EQ(point, keisan::Point2(-9.0, -3.0));
+  ASSERT_EQ(point, ksn::Point2(-9.0, -3.0));
 
   point /= 2.0;
-  ASSERT_EQ(point, keisan::Point2(-4.5, -1.5));
+  ASSERT_EQ(point, ksn::Point2(-4.5, -1.5));
 }
 
 TEST(Point2Test, PointOperator)
 {
-  auto a = keisan::Point2(1.0, 3.0);
-  auto b = keisan::Point2(2.0, 5.0);
+  auto a = ksn::Point2(1.0, 3.0);
+  auto b = ksn::Point2(2.0, 5.0);
 
-  ASSERT_EQ(a + b, keisan::Point2(3.0, 8.0));
-  ASSERT_EQ(a - b, keisan::Point2(-1.0, -2.0));
+  ASSERT_EQ(a + b, ksn::Point2(3.0, 8.0));
+  ASSERT_EQ(a - b, ksn::Point2(-1.0, -2.0));
 }
 
 TEST(Point2Test, ValueOperator)
 {
-  auto point = keisan::Point2(1.0, 3.0);
+  auto point = ksn::Point2(1.0, 3.0);
 
-  ASSERT_EQ(point + 5.0, keisan::Point2(6.0, 8.0));
-  ASSERT_EQ(point - 4.0, keisan::Point2(-3.0, -1.0));
-  ASSERT_EQ(point * 3.0, keisan::Point2(3.0, 9.0));
-  ASSERT_EQ(point / 2.0, keisan::Point2(0.5, 1.5));
+  ASSERT_EQ(point + 5.0, ksn::Point2(6.0, 8.0));
+  ASSERT_EQ(point - 4.0, ksn::Point2(-3.0, -1.0));
+  ASSERT_EQ(point * 3.0, ksn::Point2(3.0, 9.0));
+  ASSERT_EQ(point / 2.0, ksn::Point2(0.5, 1.5));
 }
 
 TEST(Point2Test, NegationOperator)
 {
-  auto point = keisan::Point2(1.0, 3.0);
-  ASSERT_EQ(-point, keisan::Point2(-1.0, -3.0));
+  auto point = ksn::Point2(1.0, 3.0);
+  ASSERT_EQ(-point, ksn::Point2(-1.0, -3.0));
 }
 
 TEST(Point2Test, Magnitude)
 {
-  auto point = keisan::Point2(3.0, 4.0);
+  auto point = ksn::Point2(3.0, 4.0);
   ASSERT_DOUBLE_EQ(point.magnitude(), 5.0);
 }
 
 TEST(Point2Test, Direction)
 {
-  auto point = keisan::Point2(0.0, 4.0);
+  auto point = ksn::Point2(0.0, 4.0);
   ASSERT_EQ(point.direction().degree(), 90.0);
 
-  point = keisan::Point2(-4.0, 0.0);
+  point = ksn::Point2(-4.0, 0.0);
   ASSERT_EQ(point.direction().degree(), 180.0);
 }
 
 TEST(Point2Test, Normalize)
 {
-  auto point = keisan::Point2(3.0, 4.0);
-  ASSERT_EQ(point.normalize(), keisan::Point2(0.6, 0.8));
+  auto point = ksn::Point2(3.0, 4.0);
+  ASSERT_EQ(point.normalize(), ksn::Point2(0.6, 0.8));
 }
 
 TEST(Point2Test, DirectionTo)
 {
-  auto a = keisan::Point2(5.0, 10.0);
-  auto b = keisan::Point2(5.0, 10.0 + 5.0);
+  auto a = ksn::Point2(5.0, 10.0);
+  auto b = ksn::Point2(5.0, 10.0 + 5.0);
 
   ASSERT_DOUBLE_EQ(a.direction_to(b).degree(), 90.0);
 }
 
 TEST(Point2Test, DistanceBetween)
 {
-  auto a = keisan::Point2(5.0, 10.0);
-  auto b = keisan::Point2(5.0 + 3.0, 10.0 + 4.0);
+  auto a = ksn::Point2(5.0, 10.0);
+  auto b = ksn::Point2(5.0 + 3.0, 10.0 + 4.0);
 
   ASSERT_DOUBLE_EQ(a.distance_to(b), 5.0);
-  ASSERT_DOUBLE_EQ(keisan::distance_between(a, b), 5.0);
+  ASSERT_DOUBLE_EQ(ksn::distance_between(a, b), 5.0);
 }
 
 TEST(Point2Test, AngleBetween)
 {
-  auto a = keisan::Point2(4.0, 3.0);
-  auto b = keisan::Point2(-3.0, 4.0);
+  auto a = ksn::Point2(4.0, 3.0);
+  auto b = ksn::Point2(-3.0, 4.0);
 
-  ASSERT_DOUBLE_EQ(keisan::angle_between(a, b).degree(), 90.0);
+  ASSERT_DOUBLE_EQ(ksn::angle_between(a, b).degree(), 90.0);
 }
 
 TEST(Point2Test, DotProduct)
 {
-  auto a = keisan::Point2(4.0, 3.0);
-  auto b = keisan::Point2(3.0, 4.0);
+  auto a = ksn::Point2(4.0, 3.0);
+  auto b = ksn::Point2(3.0, 4.0);
 
-  ASSERT_DOUBLE_EQ(keisan::dot_product(a, b), 24.0);
+  ASSERT_DOUBLE_EQ(ksn::dot_product(a, b), 24.0);
 }
 
 TEST(Point2Test, CrossProduct)
 {
-  auto a = keisan::Point2(4.0, 3.0);
-  auto b = keisan::Point2(-3.0, 4.0);
+  auto a = ksn::Point2(4.0, 3.0);
+  auto b = ksn::Point2(-3.0, 4.0);
 
-  ASSERT_DOUBLE_EQ(keisan::cross_product(a, b), 25.0);
+  ASSERT_DOUBLE_EQ(ksn::cross_product(a, b), 25.0);
 }
 
 TEST(Point2Test, Translation)
 {
-  auto point = keisan::Point2(4.0, 3.0);
-  ASSERT_EQ(point.translate({5.0, 10.0}), keisan::Point2(9.0, 13.0));
+  auto point = ksn::Point2(4.0, 3.0);
+  ASSERT_EQ(point.translate({5.0, 10.0}), ksn::Point2(9.0, 13.0));
 }
 
 TEST(Point2Test, Scaling)
 {
-  auto point = keisan::Point2(4.0, 3.0);
+  auto point = ksn::Point2(4.0, 3.0);
 
-  ASSERT_EQ(point.scale({2.0, 3.0}), keisan::Point2(8.0, 9.0));
-  ASSERT_EQ(point.scale(2.0), keisan::Point2(8.0, 6.0));
-  ASSERT_EQ(point.scale_from({2.0, 3.0}, {1.0, -1.0}), keisan::Point2(7.0, 11.0));
-  ASSERT_EQ(point.scale_from(2.0, {1.0, -1.0}), keisan::Point2(7.0, 7.0));
+  ASSERT_EQ(point.scale({2.0, 3.0}), ksn::Point2(8.0, 9.0));
+  ASSERT_EQ(point.scale(2.0), ksn::Point2(8.0, 6.0));
+  ASSERT_EQ(point.scale_from({2.0, 3.0}, {1.0, -1.0}), ksn::Point2(7.0, 11.0));
+  ASSERT_EQ(point.scale_from(2.0, {1.0, -1.0}), ksn::Point2(7.0, 7.0));
 }
 
 TEST(Point2Test, Rotation)
 {
-  auto point = keisan::Point2(4.0, 3.0);
+  auto point = ksn::Point2(4.0, 3.0);
 
-  ASSERT_EQ(point.rotate(keisan::make_degree(90.0)), keisan::Point2(-3.0, 4.0));
+  ASSERT_EQ(point.rotate(ksn::make_degree(90.0)), ksn::Point2(-3.0, 4.0));
   ASSERT_EQ(
-    point.rotate_from(keisan::make_degree(90.0), {1.0, -1.0}), keisan::Point2(-3.0, 2.0));
+    point.rotate_from(ksn::make_degree(90.0), {1.0, -1.0}), ksn::Point2(-3.0, 2.0));
 }

--- a/test/geometry/point_3_test.cpp
+++ b/test/geometry/point_3_test.cpp
@@ -24,9 +24,11 @@
 #include <sstream>
 #include <cmath>
 
+namespace ksn = keisan;
+
 TEST(Point3Test, OutStream)
 {
-  auto point = keisan::Point3(1.0, 3.0, 5.0);
+  auto point = ksn::Point3(1.0, 3.0, 5.0);
 
   std::stringstream ss;
   ss << point;
@@ -36,7 +38,7 @@ TEST(Point3Test, OutStream)
 
 TEST(Point3Test, InitialValue)
 {
-  auto point = keisan::Point3(1.0, 3.0, 5.0);
+  auto point = ksn::Point3(1.0, 3.0, 5.0);
 
   ASSERT_DOUBLE_EQ(point.x, 1.0);
   ASSERT_DOUBLE_EQ(point.y, 3.0);
@@ -45,7 +47,7 @@ TEST(Point3Test, InitialValue)
 
 TEST(Point3Test, EmptyValue)
 {
-  auto point = keisan::Point3::zero();
+  auto point = ksn::Point3::zero();
 
   ASSERT_DOUBLE_EQ(point.x, 0.0);
   ASSERT_DOUBLE_EQ(point.y, 0.0);
@@ -54,7 +56,7 @@ TEST(Point3Test, EmptyValue)
 
 TEST(Point3Test, ComparisonOperation)
 {
-  auto a = keisan::Point3(5.0, 4.0, 3.0);
+  auto a = ksn::Point3(5.0, 4.0, 3.0);
   auto b = a;
 
   ASSERT_TRUE(a == b);
@@ -68,102 +70,102 @@ TEST(Point3Test, ComparisonOperation)
 
 TEST(Point3Test, SelfPointOperator)
 {
-  auto a = keisan::Point3(5.0, 4.0, 3.0);
-  auto b = keisan::Point3(1.0, 3.0, 5.0);
+  auto a = ksn::Point3(5.0, 4.0, 3.0);
+  auto b = ksn::Point3(1.0, 3.0, 5.0);
 
   a = b;
-  ASSERT_EQ(a, keisan::Point3(1.0, 3.0, 5.0));
+  ASSERT_EQ(a, ksn::Point3(1.0, 3.0, 5.0));
 
   a += b;
-  ASSERT_EQ(a, keisan::Point3(2.0, 6.0, 10.0));
+  ASSERT_EQ(a, ksn::Point3(2.0, 6.0, 10.0));
 
   a -= b;
-  ASSERT_EQ(a, keisan::Point3(1.0, 3.0, 5.0));
+  ASSERT_EQ(a, ksn::Point3(1.0, 3.0, 5.0));
 }
 
 TEST(Point3Test, SelfValueOperator)
 {
-  auto point = keisan::Point3(1.0, 3.0, 5.0);
+  auto point = ksn::Point3(1.0, 3.0, 5.0);
 
   point += 2.0;
-  ASSERT_EQ(point, keisan::Point3(3.0, 5.0, 7.0));
+  ASSERT_EQ(point, ksn::Point3(3.0, 5.0, 7.0));
 
   point -= 6.0;
-  ASSERT_EQ(point, keisan::Point3(-3.0, -1.0, 1.0));
+  ASSERT_EQ(point, ksn::Point3(-3.0, -1.0, 1.0));
 
   point *= 3.0;
-  ASSERT_EQ(point, keisan::Point3(-9.0, -3.0, 3.0));
+  ASSERT_EQ(point, ksn::Point3(-9.0, -3.0, 3.0));
 
   point /= 2.0;
-  ASSERT_EQ(point, keisan::Point3(-4.5, -1.5, 1.5));
+  ASSERT_EQ(point, ksn::Point3(-4.5, -1.5, 1.5));
 }
 
 TEST(Point3Test, PointOperator)
 {
-  auto a = keisan::Point3(1.0, 3.0, 5.0);
-  auto b = keisan::Point3(2.0, 5.0, 10.0);
+  auto a = ksn::Point3(1.0, 3.0, 5.0);
+  auto b = ksn::Point3(2.0, 5.0, 10.0);
 
-  ASSERT_EQ(a + b, keisan::Point3(3.0, 8.0, 15.0));
-  ASSERT_EQ(a - b, keisan::Point3(-1.0, -2.0, -5.0));
+  ASSERT_EQ(a + b, ksn::Point3(3.0, 8.0, 15.0));
+  ASSERT_EQ(a - b, ksn::Point3(-1.0, -2.0, -5.0));
 }
 
 TEST(Point3Test, ValueOperator)
 {
-  auto point = keisan::Point3(1.0, 3.0, 5.0);
+  auto point = ksn::Point3(1.0, 3.0, 5.0);
 
-  ASSERT_EQ(point + 5.0, keisan::Point3(6.0, 8.0, 10.0));
-  ASSERT_EQ(point - 4.0, keisan::Point3(-3.0, -1.0, 1.0));
-  ASSERT_EQ(point * 3.0, keisan::Point3(3.0, 9.0, 15.0));
-  ASSERT_EQ(point / 2.0, keisan::Point3(0.5, 1.5, 2.5));
+  ASSERT_EQ(point + 5.0, ksn::Point3(6.0, 8.0, 10.0));
+  ASSERT_EQ(point - 4.0, ksn::Point3(-3.0, -1.0, 1.0));
+  ASSERT_EQ(point * 3.0, ksn::Point3(3.0, 9.0, 15.0));
+  ASSERT_EQ(point / 2.0, ksn::Point3(0.5, 1.5, 2.5));
 }
 
 TEST(Point3Test, NegationOperator)
 {
-  auto point = keisan::Point3(1.0, 3.0, 5.0);
-  ASSERT_EQ(-point, keisan::Point3(-1.0, -3.0, -5.0));
+  auto point = ksn::Point3(1.0, 3.0, 5.0);
+  ASSERT_EQ(-point, ksn::Point3(-1.0, -3.0, -5.0));
 }
 
 TEST(Point3Test, Magnitude)
 {
-  auto point = keisan::Point3(3.0, 0.0, 4.0);
+  auto point = ksn::Point3(3.0, 0.0, 4.0);
   ASSERT_DOUBLE_EQ(point.magnitude(), 5.0);
 }
 
 TEST(Point3Test, Normalize)
 {
-  auto point = keisan::Point3(3.0, 0.0, 4.0);
-  ASSERT_EQ(point.normalize(), keisan::Point3(0.6, 0.0, 0.8));
+  auto point = ksn::Point3(3.0, 0.0, 4.0);
+  ASSERT_EQ(point.normalize(), ksn::Point3(0.6, 0.0, 0.8));
 }
 
 TEST(Point3Test, DistanceBetween)
 {
-  auto a = keisan::Point3(1.0, 3.0, 5.0);
-  auto b = keisan::Point3(1.0 + 3.0, 3.0, 5.0 + 4.0);
+  auto a = ksn::Point3(1.0, 3.0, 5.0);
+  auto b = ksn::Point3(1.0 + 3.0, 3.0, 5.0 + 4.0);
 
   ASSERT_DOUBLE_EQ(a.distance_to(b), 5.0);
-  ASSERT_DOUBLE_EQ(keisan::distance_between(a, b), 5.0);
+  ASSERT_DOUBLE_EQ(ksn::distance_between(a, b), 5.0);
 }
 
 TEST(Point3Test, AngleBetween)
 {
-  auto a = keisan::Point3(2.0, -1.0, 7.0);
-  auto b = keisan::Point3(1.0, 2.0, 0.0);
+  auto a = ksn::Point3(2.0, -1.0, 7.0);
+  auto b = ksn::Point3(1.0, 2.0, 0.0);
 
-  ASSERT_DOUBLE_EQ(keisan::angle_between(a, b).degree(), 90.0);
+  ASSERT_DOUBLE_EQ(ksn::angle_between(a, b).degree(), 90.0);
 }
 
 TEST(Point3Test, DotProduct)
 {
-  auto a = keisan::Point3(4.0, 3.0, 2.0);
-  auto b = keisan::Point3(3.0, 4.0, 5.0);
+  auto a = ksn::Point3(4.0, 3.0, 2.0);
+  auto b = ksn::Point3(3.0, 4.0, 5.0);
 
-  ASSERT_DOUBLE_EQ(keisan::dot_product(a, b), 34.0);
+  ASSERT_DOUBLE_EQ(ksn::dot_product(a, b), 34.0);
 }
 
 TEST(Point3Test, CrossProduct)
 {
-  auto a = keisan::Point3(3.0, 6.0, -3.0);
-  auto b = keisan::Point3(0.0, 2.0, 4.0);
+  auto a = ksn::Point3(3.0, 6.0, -3.0);
+  auto b = ksn::Point3(0.0, 2.0, 4.0);
 
-  ASSERT_DOUBLE_EQ(keisan::cross_product(a, b), sqrt(54.0) * sqrt(20.0));
+  ASSERT_DOUBLE_EQ(ksn::cross_product(a, b), sqrt(54.0) * sqrt(20.0));
 }

--- a/test/geometry/transform2_test.cpp
+++ b/test/geometry/transform2_test.cpp
@@ -29,16 +29,18 @@
     ASSERT_DOUBLE_EQ(temp_point.y, (point_y)); \
   }
 
+namespace ksn = keisan;
+
 TEST(Trasform2Test, GeometryTransformation)
 {
-  auto point = keisan::Point2(3.0, 5.0);
+  auto point = ksn::Point2(3.0, 5.0);
 
-  auto transform = keisan::Transform2();
+  auto transform = ksn::Transform2();
 
   transform.set_scale({2.0, 3.0});
   ASSERT_POINT2_EQ(transform * point, 6.0, 15.0);
 
-  transform.set_rotation(keisan::make_degree(90.0));
+  transform.set_rotation(ksn::make_degree(90.0));
   ASSERT_POINT2_EQ(transform * point, -15.0, 6.0);
 
   transform.set_translation({2.0, 3.0});
@@ -47,9 +49,9 @@ TEST(Trasform2Test, GeometryTransformation)
 
 TEST(Trasform2Test, Translation)
 {
-  auto point = keisan::Point2(3.0, 5.0);
+  auto point = ksn::Point2(3.0, 5.0);
 
-  auto transform = keisan::Transform2();
+  auto transform = ksn::Transform2();
 
   transform.set_translation({0.0, 0.0});
   ASSERT_POINT2_EQ(transform * point, 3.0, 5.0);
@@ -60,22 +62,22 @@ TEST(Trasform2Test, Translation)
 
 TEST(Trasform2Test, Rotation)
 {
-  auto point = keisan::Point2(3.0, 5.0);
+  auto point = ksn::Point2(3.0, 5.0);
 
-  auto transform = keisan::Transform2();
+  auto transform = ksn::Transform2();
 
-  transform.set_rotation(keisan::make_degree(0.0));
+  transform.set_rotation(ksn::make_degree(0.0));
   ASSERT_POINT2_EQ(transform * point, 3.0, 5.0);
 
-  transform.set_rotation(keisan::make_degree(180.0));
+  transform.set_rotation(ksn::make_degree(180.0));
   ASSERT_POINT2_EQ(transform * point, -3.0, -5.0);
 }
 
 TEST(Trasform2Test, Scaling)
 {
-  auto point = keisan::Point2(3.0, 5.0);
+  auto point = ksn::Point2(3.0, 5.0);
 
-  auto transform = keisan::Transform2();
+  auto transform = ksn::Transform2();
 
   transform.set_scale({1.0, 1.0});
   ASSERT_POINT2_EQ(transform * point, 3.0, 5.0);

--- a/test/matrix/matrix_test.cpp
+++ b/test/matrix/matrix_test.cpp
@@ -25,7 +25,7 @@
 
 #define ASSERT_MATRIX_M_N_EQ(M, N, MATRIX, ...) \
   { \
-    keisan::Matrix<M, N> _matrix = MATRIX; \
+    ksn::Matrix<M, N> _matrix = MATRIX; \
     double _values[] = {__VA_ARGS__}; \
     for (size_t i = 0; i < M; ++i) { \
       for (size_t j = 0; j < N; ++j) { \
@@ -34,9 +34,11 @@
     } \
   }
 
+namespace ksn = keisan;
+
 TEST(MatrixTest, OutStream)
 {
-  auto a = keisan::Matrix<3, 4>(
+  auto a = ksn::Matrix<3, 4>(
     1.0, 1.0, 1.0, 1.0,
     2.0, 2.0, 2.0, 2.0,
     3.0, 3.0, 3.0, 3.0);
@@ -49,10 +51,10 @@ TEST(MatrixTest, OutStream)
 
 TEST(MatrixTest, InitialValue)
 {
-  auto a = keisan::Matrix<2, 1>(1.0, 2.0);
+  auto a = ksn::Matrix<2, 1>(1.0, 2.0);
   ASSERT_MATRIX_M_N_EQ(2, 1, a, 1.0, 2.0);
 
-  auto b = keisan::Matrix<3, 4>(
+  auto b = ksn::Matrix<3, 4>(
     1.0, 1.0, 1.0, 1.0,
     2.0, 2.0, 2.0, 2.0,
     3.0, 3.0, 3.0, 3.0);
@@ -66,10 +68,10 @@ TEST(MatrixTest, InitialValue)
 
 TEST(MatrixTest, ZeroValue)
 {
-  auto a = keisan::Matrix<2, 1>::zero();
+  auto a = ksn::Matrix<2, 1>::zero();
   ASSERT_MATRIX_M_N_EQ(2, 1, a, 0.0, 0.0);
 
-  auto b = keisan::Matrix<3, 4>::zero();
+  auto b = ksn::Matrix<3, 4>::zero();
   ASSERT_MATRIX_M_N_EQ(
     3, 4, b,
     0.0, 0.0, 0.0, 0.0,
@@ -79,7 +81,7 @@ TEST(MatrixTest, ZeroValue)
 
 TEST(MatrixTest, ComparisonOperation)
 {
-  auto a = keisan::Matrix<3, 4>(
+  auto a = ksn::Matrix<3, 4>(
     1.0, 1.0, 1.0, 1.0,
     2.0, 2.0, 2.0, 2.0,
     3.0, 3.0, 3.0, 3.0);
@@ -97,12 +99,12 @@ TEST(MatrixTest, ComparisonOperation)
 
 TEST(MatrixTest, MatrixMultiplication)
 {
-  auto a = keisan::Matrix<3, 2>(
+  auto a = ksn::Matrix<3, 2>(
     1.0, 1.0,
     2.0, 2.0,
     3.0, 3.0);
 
-  auto b = keisan::Matrix<2, 2>(
+  auto b = ksn::Matrix<2, 2>(
     1.0, 1.0,
     2.0, 2.0);
 
@@ -115,15 +117,15 @@ TEST(MatrixTest, MatrixMultiplication)
 
 TEST(MatrixTest, SquareMatrixMultiplication)
 {
-  auto a = keisan::SquareMatrix<2>(
+  auto a = ksn::SquareMatrix<2>(
     1.0, 1.0,
     2.0, 2.0);
 
-  auto b = keisan::Matrix<2, 3>(
+  auto b = ksn::Matrix<2, 3>(
     1.0, 1.0, 1.0,
     2.0, 2.0, 2.0);
 
-  auto c = keisan::Matrix<3, 2>(
+  auto c = ksn::Matrix<3, 2>(
     1.0, 1.0,
     2.0, 2.0,
     3.0, 3.0);
@@ -142,12 +144,12 @@ TEST(MatrixTest, SquareMatrixMultiplication)
 
 TEST(MatrixTest, MatrixOperation)
 {
-  auto a = keisan::Matrix<3, 4>(
+  auto a = ksn::Matrix<3, 4>(
     1.0, 1.0, 1.0, 1.0,
     2.0, 2.0, 2.0, 2.0,
     3.0, 3.0, 3.0, 3.0);
 
-  auto b = keisan::Matrix<3, 4>(
+  auto b = ksn::Matrix<3, 4>(
     1.0, 2.0, 3.0, 4.0,
     1.0, 2.0, 3.0, 4.0,
     1.0, 2.0, 3.0, 4.0);
@@ -181,7 +183,7 @@ TEST(MatrixTest, MatrixOperation)
 
 TEST(MatrixTest, ScalarOperation)
 {
-  auto a = keisan::Matrix<3, 4>(
+  auto a = ksn::Matrix<3, 4>(
     1.0, 1.0, 1.0, 1.0,
     2.0, 2.0, 2.0, 2.0,
     3.0, 3.0, 3.0, 3.0);
@@ -241,7 +243,7 @@ TEST(MatrixTest, ScalarOperation)
 
 TEST(MatrixTest, NegationOperation)
 {
-  auto a = keisan::Matrix<3, 4>(
+  auto a = ksn::Matrix<3, 4>(
     1.0, 1.0, 1.0, 1.0,
     2.0, 2.0, 2.0, 2.0,
     3.0, 3.0, 3.0, 3.0);

--- a/test/matrix/square_matrix_test.cpp
+++ b/test/matrix/square_matrix_test.cpp
@@ -25,7 +25,7 @@
 
 #define ASSERT_SQUARE_MATRIX_N_EQ(N, SQUARE_MATRIX, ...) \
   { \
-    keisan::SquareMatrix<N> _square_matrix = SQUARE_MATRIX; \
+    ksn::SquareMatrix<N> _square_matrix = SQUARE_MATRIX; \
     double _values[] = {__VA_ARGS__}; \
     for (size_t i = 0; i < N; ++i) { \
       for (size_t j = 0; j < N; ++j) { \
@@ -34,9 +34,11 @@
     } \
   }
 
+namespace ksn = keisan;
+
 TEST(SquareMatrixTest, OutStream)
 {
-  auto a = keisan::SquareMatrix<2>(
+  auto a = ksn::SquareMatrix<2>(
     1.0, 1.0,
     2.0, 2.0);
 
@@ -48,7 +50,7 @@ TEST(SquareMatrixTest, OutStream)
 
 TEST(SquareMatrixTest, InitialValue)
 {
-  auto a = keisan::SquareMatrix<2>(
+  auto a = ksn::SquareMatrix<2>(
     1.0, 1.0,
     2.0, 2.0);
 
@@ -57,7 +59,7 @@ TEST(SquareMatrixTest, InitialValue)
     1.0, 1.0,
     2.0, 2.0);
 
-  auto b = keisan::SquareMatrix<4>(
+  auto b = ksn::SquareMatrix<4>(
     1.0, 1.0, 1.0, 1.0,
     2.0, 2.0, 2.0, 2.0,
     3.0, 3.0, 3.0, 3.0,
@@ -73,13 +75,13 @@ TEST(SquareMatrixTest, InitialValue)
 
 TEST(SquareMatrixTest, ZeroValue)
 {
-  auto a = keisan::SquareMatrix<2>::zero();
+  auto a = ksn::SquareMatrix<2>::zero();
   ASSERT_SQUARE_MATRIX_N_EQ(
     2, a,
     0.0, 0.0,
     0.0, 0.0);
 
-  auto b = keisan::SquareMatrix<4>::zero();
+  auto b = ksn::SquareMatrix<4>::zero();
   ASSERT_SQUARE_MATRIX_N_EQ(
     4, b,
     0.0, 0.0, 0.0, 0.0,
@@ -90,13 +92,13 @@ TEST(SquareMatrixTest, ZeroValue)
 
 TEST(SquareMatrixTest, IdentityValue)
 {
-  auto a = keisan::SquareMatrix<2>::identity();
+  auto a = ksn::SquareMatrix<2>::identity();
   ASSERT_SQUARE_MATRIX_N_EQ(
     2, a,
     1.0, 0.0,
     0.0, 1.0);
 
-  auto b = keisan::SquareMatrix<4>::identity();
+  auto b = ksn::SquareMatrix<4>::identity();
   ASSERT_SQUARE_MATRIX_N_EQ(
     4, b,
     1.0, 0.0, 0.0, 0.0,
@@ -107,7 +109,7 @@ TEST(SquareMatrixTest, IdentityValue)
 
 TEST(SquareMatrixTest, ComparisonOperation)
 {
-  auto a = keisan::SquareMatrix<2>(
+  auto a = ksn::SquareMatrix<2>(
     1.0, 1.0,
     2.0, 2.0);
 
@@ -124,11 +126,11 @@ TEST(SquareMatrixTest, ComparisonOperation)
 
 TEST(SquareMatrixTest, SquareMatrixMultiplication)
 {
-  auto a = keisan::SquareMatrix<2>(
+  auto a = ksn::SquareMatrix<2>(
     1.0, 1.0,
     2.0, 2.0);
 
-  auto b = keisan::SquareMatrix<2>(
+  auto b = ksn::SquareMatrix<2>(
     3.0, 3.0,
     4.0, 4.0);
 
@@ -140,12 +142,12 @@ TEST(SquareMatrixTest, SquareMatrixMultiplication)
 
 TEST(SquareMatrixTest, MatrixOperation)
 {
-  auto a = keisan::SquareMatrix<3>(
+  auto a = ksn::SquareMatrix<3>(
     1.0, 1.0, 1.0,
     2.0, 2.0, 2.0,
     3.0, 3.0, 3.0);
 
-  auto b = keisan::SquareMatrix<3>(
+  auto b = ksn::SquareMatrix<3>(
     1.0, 2.0, 3.0,
     1.0, 2.0, 3.0,
     1.0, 2.0, 3.0);
@@ -179,7 +181,7 @@ TEST(SquareMatrixTest, MatrixOperation)
 
 TEST(SquareMatrixTest, ScalarOperation)
 {
-  auto a = keisan::SquareMatrix<3>(
+  auto a = ksn::SquareMatrix<3>(
     1.0, 1.0, 1.0,
     2.0, 2.0, 2.0,
     3.0, 3.0, 3.0);
@@ -239,7 +241,7 @@ TEST(SquareMatrixTest, ScalarOperation)
 
 TEST(SquareMatrixTest, NegationOperation)
 {
-  auto a = keisan::SquareMatrix<3>(
+  auto a = ksn::SquareMatrix<3>(
     1.0, 1.0, 1.0,
     2.0, 2.0, 2.0,
     3.0, 3.0, 3.0);

--- a/test/matrix/vector_test.cpp
+++ b/test/matrix/vector_test.cpp
@@ -25,16 +25,18 @@
 
 #define ASSERT_VECTOR_N_EQ(N, VECTOR, ...) \
   { \
-    keisan::Vector<N> _vector = VECTOR; \
+    ksn::Vector<N> _vector = VECTOR; \
     double _values[] = {__VA_ARGS__}; \
     for (size_t i = 0; i < N; ++i) { \
       ASSERT_DOUBLE_EQ(_values[i], _vector[i]); \
     } \
   }
 
+namespace ksn = keisan;
+
 TEST(VectorTest, OutStream)
 {
-  auto a = keisan::Vector<2>(1.0, 2.0);
+  auto a = ksn::Vector<2>(1.0, 2.0);
 
   std::stringstream ss;
   ss << a;
@@ -44,25 +46,25 @@ TEST(VectorTest, OutStream)
 
 TEST(VectorTest, InitialValue)
 {
-  auto a = keisan::Vector<2>(1.0, 2.0);
+  auto a = ksn::Vector<2>(1.0, 2.0);
   ASSERT_VECTOR_N_EQ(2, a, 1.0, 2.0);
 
-  auto b = keisan::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
+  auto b = ksn::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
   ASSERT_VECTOR_N_EQ(5, b, 1.0, 2.0, 3.0, 4.0, 5.0);
 }
 
 TEST(VectorTest, ZeroValue)
 {
-  auto a = keisan::Vector<2>::zero();
+  auto a = ksn::Vector<2>::zero();
   ASSERT_VECTOR_N_EQ(2, a, 0.0, 0.0);
 
-  auto b = keisan::Vector<5>::zero();
+  auto b = ksn::Vector<5>::zero();
   ASSERT_VECTOR_N_EQ(5, b, 0.0, 0.0, 0.0, 0.0, 0.0);
 }
 
 TEST(VectorTest, ComparisonOperation)
 {
-  auto a = keisan::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
+  auto a = ksn::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
   auto b = a;
 
   ASSERT_TRUE(a == b);
@@ -76,31 +78,31 @@ TEST(VectorTest, ComparisonOperation)
 
 TEST(VectorTest, MatrixMultiplication)
 {
-  auto a = keisan::Matrix<3, 2>(
+  auto a = ksn::Matrix<3, 2>(
     1.0, 1.0,
     2.0, 2.0,
     3.0, 3.0);
 
-  auto b = keisan::Vector<2>(1.0, 2.0);
+  auto b = ksn::Vector<2>(1.0, 2.0);
 
   ASSERT_VECTOR_N_EQ(3, a * b, 3.0, 6.0, 9.0);
 }
 
 TEST(VectorTest, SquareMatrixMultiplication)
 {
-  auto a = keisan::SquareMatrix<2>(
+  auto a = ksn::SquareMatrix<2>(
     1.0, 1.0,
     2.0, 2.0);
 
-  auto b = keisan::Vector<2>(1.0, 2.0);
+  auto b = ksn::Vector<2>(1.0, 2.0);
 
   ASSERT_VECTOR_N_EQ(2, a * b, 3.0, 6.0);
 }
 
 TEST(VectorTest, VectorOperation)
 {
-  auto a = keisan::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
-  auto b = keisan::Vector<5>(6.0, 7.0, 8.0, 9.0, 10.0);
+  auto a = ksn::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
+  auto b = ksn::Vector<5>(6.0, 7.0, 8.0, 9.0, 10.0);
 
   ASSERT_VECTOR_N_EQ(5, a + b, 7.0, 9.0, 11.0, 13.0, 15.0);
   ASSERT_VECTOR_N_EQ(5, a - b, -5.0, -5.0, -5.0, -5.0, -5.0);
@@ -114,7 +116,7 @@ TEST(VectorTest, VectorOperation)
 
 TEST(VectorTest, ScalarOperation)
 {
-  auto a = keisan::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
+  auto a = ksn::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
 
   ASSERT_VECTOR_N_EQ(5, a + 2.0, 3.0, 4.0, 5.0, 6.0, 7.0);
   ASSERT_VECTOR_N_EQ(5, a - 2.0, -1.0, 0.0, 1.0, 2.0, 3.0);
@@ -136,6 +138,6 @@ TEST(VectorTest, ScalarOperation)
 
 TEST(VectorTest, NegationOperation)
 {
-  auto a = keisan::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
+  auto a = ksn::Vector<5>(1.0, 2.0, 3.0, 4.0, 5.0);
   ASSERT_VECTOR_N_EQ(5, -a, -1.0, -2.0, -3.0, -4.0, -5.0);
 }

--- a/test/number_test.cpp
+++ b/test/number_test.cpp
@@ -108,6 +108,13 @@ TEST(NumberTest, ClampFloatingPoint)
   EXPECT_DOUBLE_EQ(ksn::clamp(5.5, -3.3, 2.2), 2.2) << "5.5 > 2.2";
 }
 
+TEST(NumberTest, ClampAngle)
+{
+  EXPECT_EQ(ksn::clamp(0_deg, -90_deg, 45_deg), 0_deg) << "-90 <= 0 <= 45";
+  EXPECT_EQ(ksn::clamp(-180_deg, -90_deg, 45_deg), -90_deg) << "-180 < -90";
+  EXPECT_EQ(ksn::clamp(90_deg, -90_deg, 45_deg), 45_deg) << "90 > 45";
+}
+
 TEST(NumberTest, WrapIntegral)
 {
   EXPECT_EQ(ksn::wrap(13, 10, 15), 13) <<

--- a/test/number_test.cpp
+++ b/test/number_test.cpp
@@ -21,53 +21,55 @@
 #include <gtest/gtest.h>
 #include <keisan/keisan.hpp>
 
-using namespace keisan::literals;  // NOLINT
+namespace ksn = keisan;
+
+using namespace ksn::literals;  // NOLINT
 
 TEST(NumberTest, SignIntegral)
 {
-  EXPECT_EQ(keisan::sign(0), 1) << "Sign result must be positive for zero";
-  EXPECT_EQ(keisan::sign(5), 1) << "Sign result must be positive";
-  EXPECT_EQ(keisan::sign(-5), -1) << "Sign result must be negative";
+  EXPECT_EQ(ksn::sign(0), 1) << "Sign result must be positive for zero";
+  EXPECT_EQ(ksn::sign(5), 1) << "Sign result must be positive";
+  EXPECT_EQ(ksn::sign(-5), -1) << "Sign result must be negative";
 }
 
 TEST(NumberTest, SignFloatingPoint)
 {
-  EXPECT_DOUBLE_EQ(keisan::sign(0.0), 1.0) << "Sign result must be positive for zero";
-  EXPECT_DOUBLE_EQ(keisan::sign(5.0), 1.0) << "Sign result must be positive";
-  EXPECT_DOUBLE_EQ(keisan::sign(-5.0), -1.0) << "Sign result must be negative";
+  EXPECT_DOUBLE_EQ(ksn::sign(0.0), 1.0) << "Sign result must be positive for zero";
+  EXPECT_DOUBLE_EQ(ksn::sign(5.0), 1.0) << "Sign result must be positive";
+  EXPECT_DOUBLE_EQ(ksn::sign(-5.0), -1.0) << "Sign result must be negative";
 }
 
 TEST(NumberTest, SignAngle)
 {
-  EXPECT_DOUBLE_EQ(keisan::sign(0_deg), 1.0) << "Sign result must be positive for zero";
-  EXPECT_DOUBLE_EQ(keisan::sign(90_deg), 1.0) << "Sign result must be positive";
-  EXPECT_DOUBLE_EQ(keisan::sign(-900_deg), -1.0) << "Sign result must be negative";
+  EXPECT_DOUBLE_EQ(ksn::sign(0_deg), 1.0) << "Sign result must be positive for zero";
+  EXPECT_DOUBLE_EQ(ksn::sign(90_deg), 1.0) << "Sign result must be positive";
+  EXPECT_DOUBLE_EQ(ksn::sign(-900_deg), -1.0) << "Sign result must be negative";
 }
 
 TEST(NumberTest, ScaleIntegral)
 {
-  EXPECT_EQ(keisan::scale(5, 2, 3), 6) <<
+  EXPECT_EQ(ksn::scale(5, 2, 3), 6) <<
     "5 / 2 = 2\n"
     "2 * 3 = 6";
 }
 
 TEST(NumberTest, ScaleFloatingPoint)
 {
-  EXPECT_DOUBLE_EQ(keisan::scale(3.3, 0.5, 1.5), 9.9) <<
+  EXPECT_DOUBLE_EQ(ksn::scale(3.3, 0.5, 1.5), 9.9) <<
     "3.3 / 0.5 = 6.6\n"
     "6.6 * 1.5 = 9.9";
 }
 
 TEST(NumberTest, MapIntegral)
 {
-  EXPECT_EQ(keisan::map(5, 2, 4, 0, 1), 1) <<
+  EXPECT_EQ(ksn::map(5, 2, 4, 0, 1), 1) <<
     "5 - 2 = 3\n"
     "4 - 2 = 2\n"
     "1 - 0 = 1\n"
     "scale(3, 2, 1) = 1\n"
     "1 + 0 = 1";
 
-  EXPECT_EQ(keisan::map(0, -2, -4, 0, 1), -1) <<
+  EXPECT_EQ(ksn::map(0, -2, -4, 0, 1), -1) <<
     "0 - (-2) = 2\n"
     "-4 - (-2) = -2\n"
     "1 - 0 = 1\n"
@@ -77,14 +79,14 @@ TEST(NumberTest, MapIntegral)
 
 TEST(NumberTest, MapFloatingPoint)
 {
-  EXPECT_DOUBLE_EQ(keisan::map(0.5, 0.2, 0.8, 1.0, 3.2), 2.1) <<
+  EXPECT_DOUBLE_EQ(ksn::map(0.5, 0.2, 0.8, 1.0, 3.2), 2.1) <<
     "0.5 - 0.2 = 0.3\n"
     "0.8 - 0.2 = 0.6\n"
     "3.2 - 1.0 = 2.2\n"
     "scale(0.3, 0.6, 2.2) = 1.1\n"
     "1.1 + 1.0 = 2.1";
 
-  EXPECT_DOUBLE_EQ(keisan::map(-0.1, 0.2, 0.8, -3.2, -1.0), -4.3) <<
+  EXPECT_DOUBLE_EQ(ksn::map(-0.1, 0.2, 0.8, -3.2, -1.0), -4.3) <<
     "-0.1 - 0.2 = -0.3\n"
     "0.8 - 0.2 = 0.6\n"
     "-1.0 - (-3.2) = 2.2\n"
@@ -94,33 +96,33 @@ TEST(NumberTest, MapFloatingPoint)
 
 TEST(NumberTest, ClampIntegral)
 {
-  EXPECT_EQ(keisan::clamp(5, 0, 10), 5) << "0 <= 5 <= 10";
-  EXPECT_EQ(keisan::clamp(-5, 0, 10), 0) << "-5 < 0";
-  EXPECT_EQ(keisan::clamp(15, 0, 10), 10) << "15 > 10";
+  EXPECT_EQ(ksn::clamp(5, 0, 10), 5) << "0 <= 5 <= 10";
+  EXPECT_EQ(ksn::clamp(-5, 0, 10), 0) << "-5 < 0";
+  EXPECT_EQ(ksn::clamp(15, 0, 10), 10) << "15 > 10";
 }
 
 TEST(NumberTest, ClampFloatingPoint)
 {
-  EXPECT_DOUBLE_EQ(keisan::clamp(0.5, -3.3, 2.2), 0.5) << "-3.3 <= 0.5 <= 2.2";
-  EXPECT_DOUBLE_EQ(keisan::clamp(-5.5, -3.3, 2.2), -3.3) << "-5.5 < -3.3";
-  EXPECT_DOUBLE_EQ(keisan::clamp(5.5, -3.3, 2.2), 2.2) << "5.5 > 2.2";
+  EXPECT_DOUBLE_EQ(ksn::clamp(0.5, -3.3, 2.2), 0.5) << "-3.3 <= 0.5 <= 2.2";
+  EXPECT_DOUBLE_EQ(ksn::clamp(-5.5, -3.3, 2.2), -3.3) << "-5.5 < -3.3";
+  EXPECT_DOUBLE_EQ(ksn::clamp(5.5, -3.3, 2.2), 2.2) << "5.5 > 2.2";
 }
 
 TEST(NumberTest, WrapIntegral)
 {
-  EXPECT_EQ(keisan::wrap(13, 10, 15), 13) <<
+  EXPECT_EQ(ksn::wrap(13, 10, 15), 13) <<
     "13 - 10 = 3\n"
     "15 - 10 = 5\n"
     "3 = 5 * 0 + 3\n"
     "3 + 10 = 13";
 
-  EXPECT_EQ(keisan::wrap(31, 10, 15), 11) <<
+  EXPECT_EQ(ksn::wrap(31, 10, 15), 11) <<
     "31 - 10 = 21\n"
     "15 - 10 = 5\n"
     "21 = 5 * 4 + 1\n"
     "1 + 10 = 11";
 
-  EXPECT_EQ(keisan::wrap(4, 10, 15), 14) <<
+  EXPECT_EQ(ksn::wrap(4, 10, 15), 14) <<
     "4 - 10 = -6\n"
     "15 - 10 = 5\n"
     "-6 = 5 * (-2) + 4\n"
@@ -129,19 +131,19 @@ TEST(NumberTest, WrapIntegral)
 
 TEST(NumberTest, WrapFloatingPoint)
 {
-  EXPECT_DOUBLE_EQ(keisan::wrap(0.1, -0.1, 0.3), 0.1) <<
+  EXPECT_DOUBLE_EQ(ksn::wrap(0.1, -0.1, 0.3), 0.1) <<
     "0.1 - (-0.1) = 0.2\n"
     "0.3 - (-0.1) = 0.4\n"
     "0.2 = 0.4 * 0 + 0.2\n"
     "0.2 + (-0.1) = 0.1";
 
-  EXPECT_DOUBLE_EQ(keisan::wrap(1.8, -0.1, 0.3), 0.2) <<
+  EXPECT_DOUBLE_EQ(ksn::wrap(1.8, -0.1, 0.3), 0.2) <<
     "1.8 - (-0.1) = 1.9\n"
     "0.3 - (-0.1) = 0.4\n"
     "1.9 = 0.4 * 4 + 0.3\n"
     "0.3 + (-0.1) = 0.2";
 
-  EXPECT_DOUBLE_EQ(keisan::wrap(0.1, 1.1, 1.5), 1.3) <<
+  EXPECT_DOUBLE_EQ(ksn::wrap(0.1, 1.1, 1.5), 1.3) <<
     "0.1 - (1.1) = -1.0\n"
     "1.5 - (1.1) = 0.4\n"
     "-1.0 = 0.4 * (-3) + 0.2\n"

--- a/test/number_test.cpp
+++ b/test/number_test.cpp
@@ -21,6 +21,8 @@
 #include <gtest/gtest.h>
 #include <keisan/keisan.hpp>
 
+using namespace keisan::literals;  // NOLINT
+
 TEST(NumberTest, SignIntegral)
 {
   EXPECT_EQ(keisan::sign(0), 1) << "Sign result must be positive for zero";
@@ -33,6 +35,13 @@ TEST(NumberTest, SignFloatingPoint)
   EXPECT_DOUBLE_EQ(keisan::sign(0.0), 1.0) << "Sign result must be positive for zero";
   EXPECT_DOUBLE_EQ(keisan::sign(5.0), 1.0) << "Sign result must be positive";
   EXPECT_DOUBLE_EQ(keisan::sign(-5.0), -1.0) << "Sign result must be negative";
+}
+
+TEST(NumberTest, SignAngle)
+{
+  EXPECT_DOUBLE_EQ(keisan::sign(0_deg), 1.0) << "Sign result must be positive for zero";
+  EXPECT_DOUBLE_EQ(keisan::sign(90_deg), 1.0) << "Sign result must be positive";
+  EXPECT_DOUBLE_EQ(keisan::sign(-900_deg), -1.0) << "Sign result must be negative";
 }
 
 TEST(NumberTest, ScaleIntegral)


### PR DESCRIPTION
- Separate header implementation of number functions (`number.hpp`).
- Support for `Angle` object in `sign()` and `clamp()`  functions.
- Alias `keisan` namespace with `ksn` in tests.