### PR TITLE
Make Angle Constructor Private

### DIFF
--- a/include/keisan/angle/angle.hpp
+++ b/include/keisan/angle/angle.hpp
@@ -62,9 +62,15 @@ public:
   template<typename U>
   friend class Angle;
 
+  friend Angle<T> make_degree<T>(const T & value);
+  friend Angle<T> make_radian<T>(const T & value);
+
   Angle();
+
+private:
   explicit Angle(const T & data, const bool & is_degree = false);
 
+public:
   template<typename U>
   operator Angle<U>() const;
 

--- a/src/geometry/transform2.cpp
+++ b/src/geometry/transform2.cpp
@@ -26,9 +26,11 @@
 namespace keisan
 {
 
+using namespace keisan::literals;  // NOLINT
+
 Transform2::Transform2()
 : translation(0.0, 0.0),
-  rotation(0.0),
+  rotation(0_deg),
   scale(1.0, 1.0)
 {
 }


### PR DESCRIPTION
Set `Angle<T>(const T &, const bool &)` to be private and add friend function in the `Angle<T>` so that constructor could be used in that function even if it's private.