### PR TITLE
Add Template in Quaternion and Euler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ install(DIRECTORY "include" DESTINATION ".")
 
 add_library(${PROJECT_NAME} SHARED
   "src/angle/angle.cpp"
-  "src/angle/quaternion.cpp"
   "src/angle/trigonometry.cpp"
   "src/geometry/point_2.cpp"
   "src/geometry/point_3.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ install(DIRECTORY "include" DESTINATION ".")
 
 add_library(${PROJECT_NAME} SHARED
   "src/angle/angle.cpp"
-  "src/angle/euler_angles.cpp"
+  "src/angle/euler.cpp"
   "src/angle/quaternion.cpp"
   "src/angle/trigonometry.cpp"
   "src/geometry/point_2.cpp"
@@ -47,7 +47,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(${PROJECT_NAME}_tests
     "test/angle/angle_test.cpp"
-    "test/angle/euler_angles_test.cpp"
+    "test/angle/euler_test.cpp"
     "test/angle/quaternion_test.cpp"
     "test/angle/trigonometry_test.cpp"
     "test/geometry/point_2_test.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ install(DIRECTORY "include" DESTINATION ".")
 
 add_library(${PROJECT_NAME} SHARED
   "src/angle/angle.cpp"
-  "src/angle/euler.cpp"
   "src/angle/quaternion.cpp"
   "src/angle/trigonometry.cpp"
   "src/geometry/point_2.cpp"

--- a/include/keisan/angle.hpp
+++ b/include/keisan/angle.hpp
@@ -22,7 +22,7 @@
 #define KEISAN__ANGLE_HPP_
 
 #include "keisan/angle/angle.hpp"
-#include "keisan/angle/euler_angles.hpp"
+#include "keisan/angle/euler.hpp"
 #include "keisan/angle/quaternion.hpp"
 #include "keisan/angle/trigonometry.hpp"
 

--- a/include/keisan/angle/angle.hpp
+++ b/include/keisan/angle/angle.hpp
@@ -26,6 +26,7 @@
 namespace keisan
 {
 
+// Forward declaration
 template<typename T>
 class Angle;
 

--- a/include/keisan/angle/angle.impl.hpp
+++ b/include/keisan/angle/angle.impl.hpp
@@ -174,7 +174,7 @@ Angle<T> Angle<T>::operator-() const
 template<typename T>
 T Angle<T>::degree() const
 {
-  using namespace keisan::literals;  // NOLINT
+  using keisan::literals::operator""_pi;
 
   return is_degree ? data : scale<T>(data, 1_pi, 180.0);
 }
@@ -182,7 +182,7 @@ T Angle<T>::degree() const
 template<typename T>
 T Angle<T>::radian() const
 {
-  using namespace keisan::literals;  // NOLINT
+  using keisan::literals::operator""_pi;
 
   return is_degree ? scale<T>(data, 180.0, 1_pi) : data;
 }
@@ -190,7 +190,7 @@ T Angle<T>::radian() const
 template<typename T>
 Angle<T> Angle<T>::normalize() const
 {
-  using namespace keisan::literals;  // NOLINT
+  using keisan::literals::operator""_pi;
 
   if (is_degree) {
     return make_degree(wrap<T>(data, -180.0, 180.0));

--- a/include/keisan/angle/euler.hpp
+++ b/include/keisan/angle/euler.hpp
@@ -28,30 +28,36 @@
 namespace keisan
 {
 
+// Forward declaration
+template<typename T>
 struct Euler;
+
 struct Quaternion;
 
-std::ostream & operator<<(std::ostream & out, const Euler & euler);
+template<typename T>
+std::ostream & operator<<(std::ostream & out, const Euler<T> & euler);
 
+template<typename T>
 struct Euler
 {
   Euler();
-  Euler(const Angle<double> & roll, const Angle<double> & pitch, const Angle<double> & yaw);
+  Euler(const Angle<T> & roll, const Angle<T> & pitch, const Angle<T> & yaw);
 
-  Euler(const Euler & other);
+  template<typename U>
+  operator Euler<U>() const;
 
-  Euler & operator=(const Euler & other);
-
-  bool operator==(const Euler & other) const;
-  bool operator!=(const Euler & other) const;
+  bool operator==(const Euler<T> & other) const;
+  bool operator!=(const Euler<T> & other) const;
 
   Quaternion quaternion() const;
 
-  Angle<double> roll;
-  Angle<double> pitch;
-  Angle<double> yaw;
+  Angle<T> roll;
+  Angle<T> pitch;
+  Angle<T> yaw;
 };
 
 }  // namespace keisan
+
+#include "keisan/angle/euler.impl.hpp"
 
 #endif  // KEISAN__ANGLE__EULER_HPP_

--- a/include/keisan/angle/euler.hpp
+++ b/include/keisan/angle/euler.hpp
@@ -32,6 +32,8 @@ namespace keisan
 template<typename T>
 struct Euler;
 
+// Forward declaration
+template<typename T>
 struct Quaternion;
 
 template<typename T>
@@ -49,7 +51,7 @@ struct Euler
   bool operator==(const Euler<T> & other) const;
   bool operator!=(const Euler<T> & other) const;
 
-  Quaternion quaternion() const;
+  Quaternion<T> quaternion() const;
 
   Angle<T> roll;
   Angle<T> pitch;

--- a/include/keisan/angle/euler.hpp
+++ b/include/keisan/angle/euler.hpp
@@ -18,32 +18,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef KEISAN__ANGLE__EULER_ANGLES_HPP_
-#define KEISAN__ANGLE__EULER_ANGLES_HPP_
+#ifndef KEISAN__ANGLE__EULER_HPP_
+#define KEISAN__ANGLE__EULER_HPP_
 
 #include <iostream>
 
-#include "./angle.hpp"
+#include "keisan/angle/angle.hpp"
 
 namespace keisan
 {
 
-struct EulerAngles;
+struct Euler;
 struct Quaternion;
 
-std::ostream & operator<<(std::ostream & out, const EulerAngles & euler);
+std::ostream & operator<<(std::ostream & out, const Euler & euler);
 
-struct EulerAngles
+struct Euler
 {
-  EulerAngles();
-  EulerAngles(const Angle<double> & roll, const Angle<double> & pitch, const Angle<double> & yaw);
+  Euler();
+  Euler(const Angle<double> & roll, const Angle<double> & pitch, const Angle<double> & yaw);
 
-  EulerAngles(const EulerAngles & other);
+  Euler(const Euler & other);
 
-  EulerAngles & operator=(const EulerAngles & other);
+  Euler & operator=(const Euler & other);
 
-  bool operator==(const EulerAngles & other) const;
-  bool operator!=(const EulerAngles & other) const;
+  bool operator==(const Euler & other) const;
+  bool operator!=(const Euler & other) const;
 
   Quaternion quaternion() const;
 
@@ -54,4 +54,4 @@ struct EulerAngles
 
 }  // namespace keisan
 
-#endif  // KEISAN__ANGLE__EULER_ANGLES_HPP_
+#endif  // KEISAN__ANGLE__EULER_HPP_

--- a/include/keisan/angle/euler.impl.hpp
+++ b/include/keisan/angle/euler.impl.hpp
@@ -65,16 +65,16 @@ bool Euler<T>::operator!=(const Euler<T> & other) const
 }
 
 template<typename T>
-Quaternion Euler<T>::quaternion() const
+Quaternion<T> Euler<T>::quaternion() const
 {
-  Quaternion quaternion;
+  Quaternion<T> quaternion;
 
-  double sr = sin(0.5 * roll);
-  double cr = cos(0.5 * roll);
-  double sp = sin(0.5 * pitch);
-  double cp = cos(0.5 * pitch);
-  double sy = sin(0.5 * yaw);
-  double cy = cos(0.5 * yaw);
+  T sr = sin(0.5 * roll);
+  T cr = cos(0.5 * roll);
+  T sp = sin(0.5 * pitch);
+  T cp = cos(0.5 * pitch);
+  T sy = sin(0.5 * yaw);
+  T cy = cos(0.5 * yaw);
 
   quaternion.x = sr * cp * cy - cr * sp * sy;
   quaternion.y = cr * sp * cy + sr * cp * sy;

--- a/include/keisan/angle/euler.impl.hpp
+++ b/include/keisan/angle/euler.impl.hpp
@@ -18,6 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#ifndef KEISAN__ANGLE__EULER_IMPL_HPP_
+#define KEISAN__ANGLE__EULER_IMPL_HPP_
+
 #include "keisan/angle/euler.hpp"
 #include "keisan/angle/quaternion.hpp"
 #include "keisan/angle/trigonometry.hpp"
@@ -25,46 +28,44 @@
 namespace keisan
 {
 
-std::ostream & operator<<(std::ostream & out, const Euler & euler)
+template<typename T>
+std::ostream & operator<<(std::ostream & out, const Euler<T> & euler)
 {
   return out << euler.roll << " " << euler.pitch << " " << euler.yaw;
 }
 
-Euler::Euler()
+template<typename T>
+Euler<T>::Euler()
 {
 }
 
-Euler::Euler(
-  const Angle<double> & roll, const Angle<double> & pitch, const Angle<double> & yaw)
+template<typename T>
+Euler<T>::Euler(const Angle<T> & roll, const Angle<T> & pitch, const Angle<T> & yaw)
 : roll(roll), pitch(pitch), yaw(yaw)
 {
 }
 
-Euler::Euler(const Euler & other)
-: roll(other.roll), pitch(other.pitch), yaw(other.yaw)
+template<typename T>
+template<typename U>
+Euler<T>::operator Euler<U>() const
 {
+  return Euler<U>(roll, pitch, yaw);
 }
 
-Euler & Euler::operator=(const Euler & other)
-{
-  roll = other.roll;
-  pitch = other.pitch;
-  yaw = other.yaw;
-
-  return *this;
-}
-
-bool Euler::operator==(const Euler & other) const
+template<typename T>
+bool Euler<T>::operator==(const Euler<T> & other) const
 {
   return roll == other.roll && yaw == other.yaw && pitch == other.pitch;
 }
 
-bool Euler::operator!=(const Euler & other) const
+template<typename T>
+bool Euler<T>::operator!=(const Euler<T> & other) const
 {
   return roll != other.roll || yaw != other.yaw || pitch != other.pitch;
 }
 
-Quaternion Euler::quaternion() const
+template<typename T>
+Quaternion Euler<T>::quaternion() const
 {
   Quaternion quaternion;
 
@@ -84,3 +85,5 @@ Quaternion Euler::quaternion() const
 }
 
 }  // namespace keisan
+
+#endif  // KEISAN__ANGLE__EULER_IMPL_HPP_

--- a/include/keisan/angle/quaternion.hpp
+++ b/include/keisan/angle/quaternion.hpp
@@ -26,33 +26,39 @@
 namespace keisan
 {
 
+// Forward declaration
 template<typename T>
 struct Euler;
 
+// Forward declaration
+template<typename T>
 struct Quaternion;
 
-std::ostream & operator<<(std::ostream & out, const Quaternion & quaternion);
+template<typename T>
+std::ostream & operator<<(std::ostream & out, const Quaternion<T> & quaternion);
 
+template<typename T>
 struct Quaternion
 {
   Quaternion();
-  Quaternion(const double & x, const double & y, const double & z, const double & w);
+  Quaternion(const T & x, const T & y, const T & z, const T & w);
 
-  Quaternion(const Quaternion & other);
+  template<typename U>
+  operator Quaternion<U>() const;
 
-  Quaternion & operator=(const Quaternion & other);
+  bool operator==(const Quaternion<T> & other) const;
+  bool operator!=(const Quaternion<T> & other) const;
 
-  bool operator==(const Quaternion & other) const;
-  bool operator!=(const Quaternion & other) const;
+  Euler<T> euler() const;
 
-  Euler<double> euler() const;
-
-  double x;
-  double y;
-  double z;
-  double w;
+  T x;
+  T y;
+  T z;
+  T w;
 };
 
 }  // namespace keisan
+
+#include "keisan/angle/quaternion.impl.hpp"
 
 #endif  // KEISAN__ANGLE__QUATERNION_HPP_

--- a/include/keisan/angle/quaternion.hpp
+++ b/include/keisan/angle/quaternion.hpp
@@ -26,7 +26,7 @@
 namespace keisan
 {
 
-struct EulerAngles;
+struct Euler;
 struct Quaternion;
 
 std::ostream & operator<<(std::ostream & out, const Quaternion & quaternion);
@@ -43,7 +43,7 @@ struct Quaternion
   bool operator==(const Quaternion & other) const;
   bool operator!=(const Quaternion & other) const;
 
-  EulerAngles euler() const;
+  Euler euler() const;
 
   double x;
   double y;

--- a/include/keisan/angle/quaternion.hpp
+++ b/include/keisan/angle/quaternion.hpp
@@ -26,7 +26,9 @@
 namespace keisan
 {
 
+template<typename T>
 struct Euler;
+
 struct Quaternion;
 
 std::ostream & operator<<(std::ostream & out, const Quaternion & quaternion);
@@ -43,7 +45,7 @@ struct Quaternion
   bool operator==(const Quaternion & other) const;
   bool operator!=(const Quaternion & other) const;
 
-  Euler euler() const;
+  Euler<double> euler() const;
 
   double x;
   double y;

--- a/include/keisan/angle/quaternion.impl.hpp
+++ b/include/keisan/angle/quaternion.impl.hpp
@@ -18,6 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#ifndef KEISAN__ANGLE__QUATERNION_IMPL_HPP_
+#define KEISAN__ANGLE__QUATERNION_IMPL_HPP_
+
 #include "keisan/angle/euler.hpp"
 #include "keisan/angle/quaternion.hpp"
 #include "keisan/angle/trigonometry.hpp"
@@ -27,55 +30,53 @@ using keisan::literals::operator""_pi;
 namespace keisan
 {
 
-std::ostream & operator<<(std::ostream & out, const Quaternion & quaternion)
+template<typename T>
+std::ostream & operator<<(std::ostream & out, const Quaternion<T> & quaternion)
 {
   return out << quaternion.x << " " << quaternion.y << " " << quaternion.z << " " << quaternion.w;
 }
 
-Quaternion::Quaternion()
+template<typename T>
+Quaternion<T>::Quaternion()
 {
 }
 
-Quaternion::Quaternion(const double & x, const double & y, const double & z, const double & w)
+template<typename T>
+Quaternion<T>::Quaternion(const T & x, const T & y, const T & z, const T & w)
 : x(x), y(y), z(z), w(w)
 {
 }
 
-Quaternion::Quaternion(const Quaternion & other)
-: x(other.x), y(other.y), z(other.z), w(other.w)
+template<typename T>
+template<typename U>
+Quaternion<T>::operator Quaternion<U>() const
 {
+  return Quaternion<U>(x, y, z, w);
 }
 
-Quaternion & Quaternion::operator=(const Quaternion & other)
-{
-  x = other.x;
-  y = other.y;
-  z = other.z;
-  w = other.w;
-
-  return *this;
-}
-
-bool Quaternion::operator==(const Quaternion & other) const
+template<typename T>
+bool Quaternion<T>::operator==(const Quaternion<T> & other) const
 {
   return x == other.x && y == other.y && z == other.z && w == other.w;
 }
 
-bool Quaternion::operator!=(const Quaternion & other) const
+template<typename T>
+bool Quaternion<T>::operator!=(const Quaternion<T> & other) const
 {
   return x != other.x || y != other.y || z != other.z || w != other.w;
 }
 
-Euler<double> Quaternion::euler() const
+template<typename T>
+Euler<T> Quaternion<T>::euler() const
 {
-  Euler<double> euler;
+  Euler<T> euler;
 
-  double sqx = x * x;
-  double sqy = y * y;
-  double sqz = z * z;
-  double sqw = w * w;
+  T sqx = x * x;
+  T sqy = y * y;
+  T sqz = z * z;
+  T sqw = w * w;
 
-  double sarg = -2 * (x * z - w * y) / (sqx + sqy + sqz + sqw);
+  T sarg = -2 * (x * z - w * y) / (sqx + sqy + sqz + sqw);
   if (sarg <= -0.99999) {
     euler.roll = make_radian(0.0);
     euler.pitch = make_radian(-0.5_pi);
@@ -98,3 +99,5 @@ Euler<double> Quaternion::euler() const
 }
 
 }  // namespace keisan
+
+#endif  // KEISAN__ANGLE__QUATERNION_IMPL_HPP_

--- a/src/angle/euler.cpp
+++ b/src/angle/euler.cpp
@@ -18,34 +18,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <keisan/angle/euler_angles.hpp>
-#include <keisan/angle/quaternion.hpp>
-#include <keisan/angle/trigonometry.hpp>
+#include "keisan/angle/euler.hpp"
+#include "keisan/angle/quaternion.hpp"
+#include "keisan/angle/trigonometry.hpp"
 
 namespace keisan
 {
 
-std::ostream & operator<<(std::ostream & out, const EulerAngles & euler)
+std::ostream & operator<<(std::ostream & out, const Euler & euler)
 {
   return out << euler.roll << " " << euler.pitch << " " << euler.yaw;
 }
 
-EulerAngles::EulerAngles()
+Euler::Euler()
 {
 }
 
-EulerAngles::EulerAngles(
+Euler::Euler(
   const Angle<double> & roll, const Angle<double> & pitch, const Angle<double> & yaw)
 : roll(roll), pitch(pitch), yaw(yaw)
 {
 }
 
-EulerAngles::EulerAngles(const EulerAngles & other)
+Euler::Euler(const Euler & other)
 : roll(other.roll), pitch(other.pitch), yaw(other.yaw)
 {
 }
 
-EulerAngles & EulerAngles::operator=(const EulerAngles & other)
+Euler & Euler::operator=(const Euler & other)
 {
   roll = other.roll;
   pitch = other.pitch;
@@ -54,17 +54,17 @@ EulerAngles & EulerAngles::operator=(const EulerAngles & other)
   return *this;
 }
 
-bool EulerAngles::operator==(const EulerAngles & other) const
+bool Euler::operator==(const Euler & other) const
 {
   return roll == other.roll && yaw == other.yaw && pitch == other.pitch;
 }
 
-bool EulerAngles::operator!=(const EulerAngles & other) const
+bool Euler::operator!=(const Euler & other) const
 {
   return roll != other.roll || yaw != other.yaw || pitch != other.pitch;
 }
 
-Quaternion EulerAngles::quaternion() const
+Quaternion Euler::quaternion() const
 {
   Quaternion quaternion;
 

--- a/src/angle/quaternion.cpp
+++ b/src/angle/quaternion.cpp
@@ -18,9 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <keisan/angle/euler_angles.hpp>
-#include <keisan/angle/quaternion.hpp>
-#include <keisan/angle/trigonometry.hpp>
+#include "keisan/angle/euler.hpp"
+#include "keisan/angle/quaternion.hpp"
+#include "keisan/angle/trigonometry.hpp"
 
 using keisan::literals::operator""_pi;
 
@@ -66,9 +66,9 @@ bool Quaternion::operator!=(const Quaternion & other) const
   return x != other.x || y != other.y || z != other.z || w != other.w;
 }
 
-EulerAngles Quaternion::euler() const
+Euler Quaternion::euler() const
 {
-  EulerAngles euler;
+  Euler euler;
 
   double sqx = x * x;
   double sqy = y * y;

--- a/src/angle/quaternion.cpp
+++ b/src/angle/quaternion.cpp
@@ -66,9 +66,9 @@ bool Quaternion::operator!=(const Quaternion & other) const
   return x != other.x || y != other.y || z != other.z || w != other.w;
 }
 
-Euler Quaternion::euler() const
+Euler<double> Quaternion::euler() const
 {
-  Euler euler;
+  Euler<double> euler;
 
   double sqx = x * x;
   double sqy = y * y;

--- a/test/angle/angle_test.cpp
+++ b/test/angle/angle_test.cpp
@@ -96,20 +96,20 @@ TEST(AngleTest, AssignmentConstructor)
 
   #define LOOP_EXPECT_CONVERSION_CONSTRUCTOR(TYPE) \
   { \
-    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, float_angle); \
-    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, double_angle); \
-    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, long_double_angle); \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, float_angle) \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, double_angle) \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, long_double_angle) \
   }
 
-  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(float);
-  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(double);
-  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(long double);
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(float)
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(double)
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(long double)
 }
 
 TEST(AngleTest, ComparisonOperator)
 {
-  auto a = 90.0_deg;
-  auto b = -180.0_deg;
+  auto a = 90_deg;
+  auto b = -180_deg;
   auto c = -1_pi_rad;
 
   EXPECT_TRUE(b == c && a != c) <<
@@ -154,7 +154,7 @@ TEST(AngleTest, NegationOperator)
 
 TEST(AngleTest, Conversion)
 {
-  auto a = 270.0_deg;
+  auto a = 270_deg;
   auto b = -0.5_pi_rad;
 
   EXPECT_DOUBLE_EQ(a.degree(), 270.0);
@@ -172,9 +172,9 @@ TEST(AngleTest, Normalize)
 TEST(AngleTest, Difference)
 {
   auto a = -1_pi_rad;
-  auto b = 270.0_deg;
+  auto b = 270_deg;
 
-  EXPECT_EQ(a.difference_to(b), 90.0_deg) <<
+  EXPECT_EQ(a.difference_to(b), 90_deg) <<
     "-1pi + 0 * 2pi = -1pi\n"
     "270 + (-1) * 360  = -90\n"
     "-90 - (-1pi) = 90";

--- a/test/angle/angle_test.cpp
+++ b/test/angle/angle_test.cpp
@@ -22,12 +22,13 @@
 #include <sstream>
 
 #include "gtest/gtest.h"
-
 #include "keisan/keisan.hpp"
 
 namespace ksn = keisan;
 
-using namespace ksn::literals;  // NOLINT
+using ksn::literals::operator""_deg;
+using ksn::literals::operator""_pi;
+using ksn::literals::operator""_pi_rad;
 
 TEST(AngleTest, MakeDegree)
 {

--- a/test/angle/euler_test.cpp
+++ b/test/angle/euler_test.cpp
@@ -18,25 +18,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <gtest/gtest.h>
-#include <keisan/keisan.hpp>
+#include "gtest/gtest.h"
+#include "keisan/keisan.hpp"
 
 namespace ksn = keisan;
 
-using namespace ksn::literals;  // NOLINT
+using ksn::literals::operator""_deg;
+using ksn::literals::operator""_pi_rad;
 
-TEST(EulerAnglesTest, Empty) {
-  ksn::EulerAngles euler;
+TEST(EulerTest, Empty) {
+  ksn::Euler euler;
 }
 
-TEST(EulerAnglesTest, AssignValue) {
-  ksn::EulerAngles a(0.0_deg, 90.0_deg, 180.0_deg);
+TEST(EulerTest, AssignValue) {
+  ksn::Euler a(0.0_deg, 90.0_deg, 180.0_deg);
 
   ASSERT_DOUBLE_EQ(a.roll.degree(), 0.0);
   ASSERT_DOUBLE_EQ(a.pitch.degree(), 90.0);
   ASSERT_DOUBLE_EQ(a.yaw.degree(), 180.0);
 
-  ksn::EulerAngles b;
+  ksn::Euler b;
   b = a;
 
   ASSERT_EQ(a.roll, b.roll);
@@ -44,10 +45,10 @@ TEST(EulerAnglesTest, AssignValue) {
   ASSERT_EQ(a.yaw, b.yaw);
 }
 
-TEST(EulerAnglesTest, ComparisonOperator) {
-  ksn::EulerAngles a(0.0_deg, 90.0_deg, 180.0_deg);
+TEST(EulerTest, ComparisonOperator) {
+  ksn::Euler a(0.0_deg, 90.0_deg, 180.0_deg);
 
-  ksn::EulerAngles b = a;
+  ksn::Euler b = a;
 
   ASSERT_TRUE(a == b);
   ASSERT_FALSE(a != b);
@@ -58,8 +59,8 @@ TEST(EulerAnglesTest, ComparisonOperator) {
   ASSERT_TRUE(a != b);
 }
 
-TEST(EulerAnglesTest, QuaternionConversion) {
-  ksn::EulerAngles euler(0.0_deg, 0.0_deg, 90.0_deg);
+TEST(EulerTest, QuaternionConversion) {
+  ksn::Euler euler(0.0_deg, 0.0_deg, 90.0_deg);
 
   auto quaternion = euler.quaternion();
 

--- a/test/angle/euler_test.cpp
+++ b/test/angle/euler_test.cpp
@@ -26,29 +26,60 @@ namespace ksn = keisan;
 using ksn::literals::operator""_deg;
 using ksn::literals::operator""_pi_rad;
 
-TEST(EulerTest, Empty) {
-  ksn::Euler euler;
+TEST(EulerTest, Empty)
+{
+  ksn::Euler<float> float_euler;
+  ksn::Euler<double> double_euler;
+  ksn::Euler<long double> long_double_euler;
 }
 
-TEST(EulerTest, AssignValue) {
-  ksn::Euler a(0.0_deg, 90.0_deg, 180.0_deg);
+TEST(EulerTest, RpyConstructor)
+{
+  #define EXPECT_RPY_CONSTRUCTOR(TYPE) \
+  { \
+    ksn::Euler<TYPE> euler(0_deg, 90_deg, 180_deg); \
+    EXPECT_DOUBLE_EQ(euler.roll.degree(), 0.0); \
+    EXPECT_DOUBLE_EQ(euler.pitch.degree(), 90.0); \
+    EXPECT_DOUBLE_EQ(euler.yaw.degree(), 180.0); \
+  }
 
-  ASSERT_DOUBLE_EQ(a.roll.degree(), 0.0);
-  ASSERT_DOUBLE_EQ(a.pitch.degree(), 90.0);
-  ASSERT_DOUBLE_EQ(a.yaw.degree(), 180.0);
-
-  ksn::Euler b;
-  b = a;
-
-  ASSERT_EQ(a.roll, b.roll);
-  ASSERT_EQ(a.pitch, b.pitch);
-  ASSERT_EQ(a.yaw, b.yaw);
+  EXPECT_RPY_CONSTRUCTOR(float);
+  EXPECT_RPY_CONSTRUCTOR(double);
+  EXPECT_RPY_CONSTRUCTOR(long double);
 }
 
-TEST(EulerTest, ComparisonOperator) {
-  ksn::Euler a(0.0_deg, 90.0_deg, 180.0_deg);
+TEST(EulerTest, AssignmentConstructor)
+{
+  #define EXPECT_CONVERSION_CONSTRUCTOR(TYPE, SOURCE) \
+  { \
+    ksn::Euler<TYPE> a(SOURCE), b = SOURCE, c; \
+    c = SOURCE; \
+    EXPECT_EQ(a, SOURCE); \
+    EXPECT_EQ(b, SOURCE); \
+    EXPECT_EQ(c, SOURCE); \
+  }
 
-  ksn::Euler b = a;
+  ksn::Euler<float> float_euler(90_deg, 90_deg, 90_deg);
+  ksn::Euler<double> double_euler(-45_deg, -45_deg, -45_deg);
+  ksn::Euler<long double> long_double_euler(15_deg, 15_deg, 15_deg);
+
+  #define LOOP_EXPECT_CONVERSION_CONSTRUCTOR(TYPE) \
+  { \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, float_euler) \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, double_euler) \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, long_double_euler) \
+  }
+
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(float)
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(double)
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(long double)
+}
+
+TEST(EulerTest, ComparisonOperator)
+{
+  ksn::Euler<double> a(0.0_deg, 90.0_deg, 180.0_deg);
+
+  auto b = a;
 
   ASSERT_TRUE(a == b);
   ASSERT_FALSE(a != b);
@@ -59,8 +90,9 @@ TEST(EulerTest, ComparisonOperator) {
   ASSERT_TRUE(a != b);
 }
 
-TEST(EulerTest, QuaternionConversion) {
-  ksn::Euler euler(0.0_deg, 0.0_deg, 90.0_deg);
+TEST(EulerTest, QuaternionConversion)
+{
+  ksn::Euler<double> euler(0.0_deg, 0.0_deg, 90.0_deg);
 
   auto quaternion = euler.quaternion();
 

--- a/test/angle/euler_test.cpp
+++ b/test/angle/euler_test.cpp
@@ -43,9 +43,9 @@ TEST(EulerTest, RpyConstructor)
     EXPECT_DOUBLE_EQ(euler.yaw.degree(), 180.0); \
   }
 
-  EXPECT_RPY_CONSTRUCTOR(float);
-  EXPECT_RPY_CONSTRUCTOR(double);
-  EXPECT_RPY_CONSTRUCTOR(long double);
+  EXPECT_RPY_CONSTRUCTOR(float)
+  EXPECT_RPY_CONSTRUCTOR(double)
+  EXPECT_RPY_CONSTRUCTOR(long double)
 }
 
 TEST(EulerTest, AssignmentConstructor)

--- a/test/angle/quaternion_test.cpp
+++ b/test/angle/quaternion_test.cpp
@@ -18,35 +18,65 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#include <gtest/gtest.h>
-#include <keisan/keisan.hpp>
+#include "gtest/gtest.h"
+#include "keisan/keisan.hpp"
 
 namespace ksn = keisan;
 
-TEST(QuaternionTest, Empty) {
-  ksn::Quaternion quaternion;
+TEST(QuaternionTest, Empty)
+{
+  ksn::Quaternion<float> float_quaternion;
+  ksn::Quaternion<double> double_quaternion;
+  ksn::Quaternion<long double> long_double_quaternion;
 }
 
-TEST(QuaternionTest, AssignValue) {
-  ksn::Quaternion a(1.0, 0.5, 0.0, -0.5);
+TEST(QuaternionTest, XyzwConstructor)
+{
+  #define EXPECT_XYZW_CONSTRUCTOR(TYPE) \
+  { \
+    ksn::Quaternion<TYPE> quaternion(1.0, 0.5, 0.0, -0.5); \
+    EXPECT_DOUBLE_EQ(quaternion.x, 1.0); \
+    EXPECT_DOUBLE_EQ(quaternion.y, 0.5); \
+    EXPECT_DOUBLE_EQ(quaternion.z, 0.0); \
+    EXPECT_DOUBLE_EQ(quaternion.w, -0.5); \
+  }
 
-  ASSERT_DOUBLE_EQ(a.x, 1.0);
-  ASSERT_DOUBLE_EQ(a.y, 0.5);
-  ASSERT_DOUBLE_EQ(a.z, 0.0);
-  ASSERT_DOUBLE_EQ(a.w, -0.5);
+  EXPECT_XYZW_CONSTRUCTOR(float)
+  EXPECT_XYZW_CONSTRUCTOR(double)
+  EXPECT_XYZW_CONSTRUCTOR(long double)
+}
 
-  ksn::Quaternion b;
-  b = a;
+TEST(QuaternionTest, AssignmentConstructor)
+{
+  #define EXPECT_CONVERSION_CONSTRUCTOR(TYPE, SOURCE) \
+  { \
+    ksn::Quaternion<TYPE> a(SOURCE), b = SOURCE, c; \
+    c = SOURCE; \
+    EXPECT_EQ(a, SOURCE); \
+    EXPECT_EQ(b, SOURCE); \
+    EXPECT_EQ(c, SOURCE); \
+  }
 
-  ASSERT_DOUBLE_EQ(a.x, b.x);
-  ASSERT_DOUBLE_EQ(a.y, b.y);
-  ASSERT_DOUBLE_EQ(a.z, b.z);
-  ASSERT_DOUBLE_EQ(a.w, b.w);
+  ksn::Quaternion<float> float_quaternion(1.0f, 1.0f, 1.0f, 1.0f);
+  ksn::Quaternion<double> double_quaternion(0.5, 0.5, 0.5, 0.5);
+  ksn::Quaternion<long double> long_double_quaternion(-0.5l, -0.5l, -0.5l, -0.5l);
+
+  #define LOOP_EXPECT_CONVERSION_CONSTRUCTOR(TYPE) \
+  { \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, float_quaternion) \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, double_quaternion) \
+    EXPECT_CONVERSION_CONSTRUCTOR(TYPE, long_double_quaternion) \
+  }
+
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(float)
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(double)
+  LOOP_EXPECT_CONVERSION_CONSTRUCTOR(long double)
 }
 
 TEST(QuaternionTest, ComparisonOperator) {
-  ksn::Quaternion a(1.0, 0.5, 0.0, -0.5);
-  ksn::Quaternion b = a;
+  ksn::Quaternion<double> a(1.0, 0.5, 0.0, -0.5);
+
+  auto b = a;
 
   ASSERT_TRUE(a == b);
   ASSERT_FALSE(a != b);

--- a/test/angle/trigonometry_test.cpp
+++ b/test/angle/trigonometry_test.cpp
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 #include "gtest/gtest.h"
-
 #include "keisan/keisan.hpp"
 
 namespace ksn = keisan;


### PR DESCRIPTION
- Rename `EulerAngles` into `Euler`.
- Use template in `Euler` object (`Euler<T>`) and `Quaternion` object (`Quaternion<T>`).