### PR TITLE
[Enhancement] - Rotation Matrix from Quaternion

### DIFF
--- a/include/keisan/matrix/matrix.hpp
+++ b/include/keisan/matrix/matrix.hpp
@@ -91,6 +91,8 @@ Matrix<3, 3> rotation_matrix(const Angle<double> & angle);
 
 Matrix<4, 4> rotation_matrix(const Euler<double> & angle);
 
+Matrix<4, 4> rotation_matrix(const Quaternion<double> & quaternion);
+
 }  // namespace keisan
 
 template<size_t M, size_t N>

--- a/src/matrix/matrix.cpp
+++ b/src/matrix/matrix.cpp
@@ -70,6 +70,37 @@ Matrix<4, 4> rotation_matrix(const Euler<double> & angle)
   return (yaw * pitch) * roll;
 }
 
+Matrix<4, 4> rotation_matrix(const Quaternion<double> & quat)
+{
+  auto matrix = Matrix<4, 4>::identity();
+
+  double xx = quat.x * quat.x;
+  double yy = quat.y * quat.y;
+  double zz = quat.z * quat.z;
+
+  double xy = quat.x * quat.y;
+  double xz = quat.x * quat.z;
+  double yz = quat.y * quat.z;
+
+  double wx = quat.w * quat.x;
+  double wy = quat.w * quat.y;
+  double wz = quat.w * quat.z;
+
+  matrix[0][0] = 1 - 2 * (yy + zz);
+  matrix[0][1] = 2 * (xy - wz);
+  matrix[0][2] = 2 * (xz + wy);
+
+  matrix[1][0] = 2 * (xy + wz);
+  matrix[1][1] = 1 - 2 * (xx + zz);
+  matrix[1][2] = 2 * (yz - wx);
+
+  matrix[2][0] = 2 * (xz - wy);
+  matrix[2][1] = 2 * (yz + wx);
+  matrix[2][2] = 1 - 2 * (xx + yy);
+
+  return matrix;
+}
+
 Matrix<3, 3> rotation_matrix(const Angle<double> & angle)
 {
   auto matrix = Matrix<3, 3>::identity();


### PR DESCRIPTION
## Jira Link: 

## Description

Add function to create rotation matrix from the given quaternion. Note that the quaternion must be a unit quaternion, i. e. x^2 + y^2 + z^2 + w^2 = 1.

## Type of Change

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.