### PR TITLE
hotfix: typo in kalman filter

### DIFF
--- a/include/keisan/kalman.hpp
+++ b/include/keisan/kalman.hpp
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#ifndef KEISAN__KEISAN_HPP_
-#define KEISAN__KEISAN_HPP_
+#ifndef KEISAN__KALMAN_HPP_
+#define KEISAN__KALMAN_HPP_
 
 #include "keisan/matrix.hpp"
 
@@ -29,6 +29,8 @@ namespace keisan
 class Kalman
 {
 public:
+  Kalman() = default;
+  ~Kalman() = default;
   Kalman(double dt, double std_dev_aceleration, Matrix<2, 1> std_measurement, Matrix<2, 1> acceleration); 
   Matrix<4, 1> predict();
   Matrix<4, 1> update(Matrix<2, 1> measurement);
@@ -46,4 +48,4 @@ private:
 
 } // namespace keisa
 
-#endif // KEISAN__KEISAN_HPP_
+#endif // KEISAN__KALMAN_HPP_


### PR DESCRIPTION
## Jira Link: 

## Description
typo in header guard name in kalman.hpp, and add missing default constructor and destructor

## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [ ] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.